### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
+bundler_args: --without development
 rvm:
   - 1.9.3
   - 2.0.0
   - jruby-19mode # JRuby (1.9)
-  - rbx-19mode
+  - rbx

--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,21 @@ gemspec
 
 gem 'jruby-openssl', "~> 0.9.0", platform: :jruby
 
-group :development do 
+group :development do
   gem "ruby-debug", "~> 0.10.4", platform: :jruby
   gem "debugger", "~> 1.5.0", platform: :mri
 end
 
-group :test do 
+group :test do
   gem "coveralls", "~> 0.7.0", :require => false
+  gem "rake", "~> 10.1.0"
+  gem "vcr", "~> 2.5.0"
+  gem "webmock", "~> 1.13.0"
+end
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0' # if using anything in the ruby standard library
+  gem 'rubinius-coverage'
+  gem 'rubysl-test-unit'
+  gem "racc"
 end


### PR DESCRIPTION
rbx-19mode is no longer valid.
See http://rubini.us/2013/12/03/testing-with-rbx-on-travis/

This also tells the Travis bundler to not install development gems as recommended
by Travis docs (which required adding some gems as test dependencies).
