### PR TITLE
Bugfix for related_links method

### DIFF
--- a/lib/exlibris/primo/pnx/links.rb
+++ b/lib/exlibris/primo/pnx/links.rb
@@ -18,7 +18,7 @@ module Exlibris
         # Parse addlink tags to find related links
         #
         def related_links
-          @fulltexts ||= 
+          @related_links ||= 
             links("addlink").collect { |link_attributes| 
               Exlibris::Primo::RelatedLink.new link_attributes }
         end


### PR DESCRIPTION
Bugfix to prevent colliding instance variable name with `fulltexts` method.
