### PR TITLE
 added the display code to the links

### DIFF
--- a/lib/exlibris/primo/link.rb
+++ b/lib/exlibris/primo/link.rb
@@ -1,8 +1,8 @@
 module Exlibris
   module Primo
-    # 
+    #
     # Abstract class representing a link in Primo.
-    # 
+    #
     class Link
       include Abstract
       include Config::Attributes
@@ -11,7 +11,7 @@ module Exlibris
       self.abstract = true
 
       attr_accessor :institution, :record_id, :original_id,
-        :url, :display, :notes, :subfields
+        :url, :display, :notes, :subfields, :display_code
 
       def initialize *args
         # URLs may have XML escaped ampersands
@@ -21,19 +21,19 @@ module Exlibris
       end
     end
 
-    # 
+    #
     # Primo fulltext link.
-    # 
+    #
     class Fulltext < Link; end
 
-    # 
+    #
     # Primo table of contents link.
-    # 
+    #
     class TableOfContents < Link; end
 
-    # 
+    #
     # Primo related link.
-    # 
+    #
     class RelatedLink < Link; end
   end
 end

--- a/lib/exlibris/primo/pnx/links.rb
+++ b/lib/exlibris/primo/pnx/links.rb
@@ -1,34 +1,34 @@
 module Exlibris
   module Primo
     module Pnx
-      # 
+      #
       # Handle links in links tags.
-      # 
+      #
       module Links
         #
         # Parse linktorsrc tags to find full text links
         #
         def fulltexts
-          @fulltexts ||= 
-            links("linktorsrc").collect { |link_attributes| 
+          @fulltexts ||=
+            links("linktorsrc").collect { |link_attributes|
               Exlibris::Primo::Fulltext.new link_attributes }
         end
-        
+
         #
         # Parse addlink tags to find related links
         #
         def related_links
-          @fulltexts ||= 
-            links("addlink").collect { |link_attributes| 
+          @fulltexts ||=
+            links("addlink").collect { |link_attributes|
               Exlibris::Primo::RelatedLink.new link_attributes }
         end
-        
+
         #
         # Parse linktotoc tags to find table of contents links
         #
         def tables_of_contents
-          @tables_of_contents ||= 
-            links("linktotoc").collect { |link_attributes| 
+          @tables_of_contents ||=
+            links("linktotoc").collect { |link_attributes|
               Exlibris::Primo::TableOfContents.new link_attributes }
         end
 
@@ -44,7 +44,7 @@ module Exlibris
             next if subfields["U"].nil?
             { :institution => subfields["I"],
               :record_id => recordid, :original_id => original_id,
-              :url => subfields["U"], :display => subfields["D"] }
+              :url => subfields["U"], :display => subfields["D"], :display_code => subfields['E'] }
           end
         end
         private :links

--- a/test/pnx/links_test.rb
+++ b/test/pnx/links_test.rb
@@ -15,6 +15,11 @@ module Pnx
       assert_not_nil(record.fulltexts.first.display)
     end
 
+    def test_fulltexs_with_title_in_template_field
+      record = Exlibris::Primo::Record.new(:raw_xml => dedupmgr_record_xml)
+      assert_equal("linktosrc_code", record.fulltexts[1].display_code)
+    end
+
     def test_tables_of_contents
       record = Exlibris::Primo::Record.new(:raw_xml => dedupmgr_record_xml)
       assert_not_nil record.tables_of_contents

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -144,6 +144,7 @@ class Test::Unit::TestCase
     "<backlink>$$V$$Taleph_backlink$$DMore bibliographic information$$Onyu_aleph000932393</backlink>"+
     "<backlink>$$V$$Taleph_backlink$$DMore bibliographic information$$Onyu_aleph002959842</backlink>"+
     "<linktorsrc>$$V$$Uhttps://ezproxy.library.nyu.edu/login?url=http://proquest.umi.com/pqdweb?RQT=318&amp;VName=PQD&amp;clientid=9269&amp;pmid=7818$$D1995 - Current Access via Proquest$$INYU$$Onyu_aleph000932393</linktorsrc>"+
+    "<linktorsrc>$$V$$Uhttps://ezproxy.library.nyu.edu/login?url=http://proquest.umi.com/pqdweb?RQT=318&amp;VName=PQD&amp;clientid=9269&amp;pmid=7818$$Elinktosrc_code$$INYUAD$$Onyu_aleph000932393</linktorsrc>"+
     "<linktorsrc>$$V$$Uhttps://ezproxy.library.nyu.edu/login?url=http://proquest.umi.com/pqdweb?RQT=318&amp;VName=PQD&amp;clientid=9269&amp;pmid=7818$$D1995 - Current Access via Proquest$$INYUAD$$Onyu_aleph000932393</linktorsrc>"+
     "<linktorsrc>$$V$$Uhttps://ezproxy.library.nyu.edu/login?url=http://www.nytimes.com/$$DOnline version:$$INYU$$Onyu_aleph002959842</linktorsrc>"+
     "<linktorsrc>$$V$$Uhttps://ezproxy.library.nyu.edu/login?url=http://www.nytimes.com/$$DOnline version:$$INYUAD$$Onyu_aleph002959842</linktorsrc>"+


### PR DESCRIPTION
Basically for links primo seems to either send a $$D or a $$E.  With one or the other being required.   $$E is a code that gets translated into the actual title.    In our instance of primo many of the fulltext links are only sending the display code. 

There is more info in the technical guide. 
http://www.customercenter.exlibrisgroup.com/_layouts/Netwise/ExlibrisLogin.aspx?ReturnUrl=%2fDocumentationCenter%2f_layouts%2fAuthenticate.aspx%3fSource%3d%252fDocumentationCenter%252fEx%252520Libris%252520Documentation%252fPrimo%252fTechnical%252520Documentation%252fVersion%2525204.x%252fStaff%252520User%252520Information%252fPrimo%252520Technical%252520Guide.pdf&Source=%2fDocumentationCenter%2fEx%2520Libris%2520Documentation%2fPrimo%2fTechnical%2520Documentation%2fVersion%25204.x%2fStaff%2520User%2520Information%2fPrimo%2520Technical%2520Guide.pdf
