### PR TITLE
Update to Savon gem to fix entity escaping issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
   - 1.9.3
   - 2.0.0
   - jruby-19mode # JRuby (1.9)
-  - rbx
+  - rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :test do
   gem "rake", "~> 10.1.0"
   gem "vcr", "~> 2.5.0"
   gem "webmock", "~> 1.13.0"
+  gem "minitest", "4.7.5"
 end
 
 platforms :rbx do

--- a/exlibris-primo.gemspec
+++ b/exlibris-primo.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 3.2.14"
   s.add_dependency "nokogiri", "~> 1.6.0"
   s.add_dependency "json", "~> 1.8.0"
-  s.add_dependency "savon", "~> 2.2.0"
+  s.add_dependency "savon", "~> 2.5.0"
   s.add_dependency "iso-639", "~> 0.2.0"
   s.add_development_dependency "rake", "~> 10.1.0"
   s.add_development_dependency "vcr", "~> 2.8.0"

--- a/lib/exlibris/primo/pnx/elements.rb
+++ b/lib/exlibris/primo/pnx/elements.rb
@@ -1,9 +1,9 @@
 module Exlibris
   module Primo
     module Pnx
-      # 
+      #
       # Provides access to PNX elements
-      # 
+      #
       module Elements
         #
         # Parses elements from PNX base on the pattern
@@ -44,25 +44,25 @@ module Exlibris
 
         def attr_read method
           if("#{method}".start_with? "all_")
-            (inner_html_all(xpathize(method)) || inner_html_all(controlize(method)))
+            (inner_text_all(xpathize(method)) || inner_text_all(controlize(method)))
           else
-            (inner_html_at(xpathize(method)) || inner_html_at(controlize(method)))
+            (inner_text_at(xpathize(method)) || inner_text_at(controlize(method)))
           end
         end
         private :attr_read
 
-        def inner_html_all xpath
+        def inner_text_all xpath
           xml.root.xpath(xpath).collect do |element|
-            element.inner_html
+            element.inner_text
           end
         end
-        private :inner_html_all
+        private :inner_text_all
 
-        def inner_html_at xpath
+        def inner_text_at xpath
           xml_at = xml.root.at_xpath(xpath)
-          xml_at.inner_html if xml_at
+          xml_at.inner_text if xml_at
         end
-        private :inner_html_at
+        private :inner_text_at
 
         def controlize s
           "control/#{xpathize s.to_s}"

--- a/lib/exlibris/primo/web_service/response/base.rb
+++ b/lib/exlibris/primo/web_service/response/base.rb
@@ -19,11 +19,8 @@ module Exlibris
             @code = savon_response.http.code
             @body = savon_response.http.body
             @soap_action = soap_action
-            # Primo's XML is unescaped trash that Nokogiri chokes on.
-            # Force & to &amp; and avoid double escaping
-            # This is a complete HACK.
-            @raw_xml = savon_response.body[response_key][return_key].
-              gsub('&amp;', '&').gsub('&', '&amp;')
+
+            @raw_xml = savon_response.body[response_key][return_key]
           end
         end
       end

--- a/test/search_primo_central_test.rb
+++ b/test/search_primo_central_test.rb
@@ -37,7 +37,7 @@ class SearchPrimoCentralTest < Test::Unit::TestCase
       assert_not_nil record.fulltexts
       assert_not_nil record.tables_of_contents
       assert_not_nil record.related_links
-      assert_equal "MLA International Bibliography&lt;img src=\"http://exlibris-pub.s3.amazonaws.com/mlalogo_001.jpg\" style=\"vertical-align:middle;margin-left:7px\"&gt;", record.display_source
+      assert_equal "MLA International Bibliography<img src=\"http://exlibris-pub.s3.amazonaws.com/mlalogo_001.jpg\" style=\"vertical-align:middle;margin-left:7px\">", record.display_source
     end
   end
 end

--- a/test/search_primo_central_test.rb
+++ b/test/search_primo_central_test.rb
@@ -4,6 +4,7 @@ class SearchPrimoCentralTest < Test::Unit::TestCase
     @base_url = "http://primo-fe1.library.nd.edu:1701"
     @institution = "NDU"
     @search_term = "van gogh"
+    @mla_doc_id = "mla2012444463"
   end
 
   def test_primo_central
@@ -20,6 +21,23 @@ class SearchPrimoCentralTest < Test::Unit::TestCase
         assert_not_nil record.tables_of_contents
         assert_not_nil record.related_links
       end
+    end
+  end
+
+  def test_mla_source
+    VCR.use_cassette('search primo central mla') do
+      search = Exlibris::Primo::Search.new.base_url!(@base_url).
+        institution!(@institution).add_adaptor_location('primo_central_multiple_fe').add_query_term(@mla_doc_id, "rid", "exact").on_campus
+      assert_not_nil search.records
+      assert((not search.records.empty?))
+      assert_not_nil search.size
+      record = search.records.first
+      assert record.respond_to?(:display_title), "Record should have a display title"
+      assert_not_nil record.display_title
+      assert_not_nil record.fulltexts
+      assert_not_nil record.tables_of_contents
+      assert_not_nil record.related_links
+      assert_equal record.display_source, "MLA International Bibliography<img src=\"http://exlibris-pub.s3.amazonaws.com/mlalogo_001.jpg\" style=\"vertical-align:middle;margin-left:7px\">"
     end
   end
 end

--- a/test/search_primo_central_test.rb
+++ b/test/search_primo_central_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 class SearchPrimoCentralTest < Test::Unit::TestCase
   def setup
-    @base_url = "http://onesearch.library.nd.edu"
-    @search_term = "van gogh"
+    @base_url = "http://primo-fe1.library.nd.edu:1701"
     @institution = "NDU"
+    @search_term = "van gogh"
   end
 
   def test_primo_central

--- a/test/search_primo_central_test.rb
+++ b/test/search_primo_central_test.rb
@@ -37,7 +37,7 @@ class SearchPrimoCentralTest < Test::Unit::TestCase
       assert_not_nil record.fulltexts
       assert_not_nil record.tables_of_contents
       assert_not_nil record.related_links
-      assert_equal record.display_source, "MLA International Bibliography<img src=\"http://exlibris-pub.s3.amazonaws.com/mlalogo_001.jpg\" style=\"vertical-align:middle;margin-left:7px\">"
+      assert_equal "MLA International Bibliography&lt;img src=\"http://exlibris-pub.s3.amazonaws.com/mlalogo_001.jpg\" style=\"vertical-align:middle;margin-left:7px\"&gt;", record.display_source
     end
   end
 end

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -209,7 +209,7 @@ class SearchTest < Test::Unit::TestCase
       assert_not_nil search.records
       assert((not search.records.empty?))
       search.records.each do |record|
-        assert_match(/(&lt;|<)span class="searchword"(&gt;|>)/, record.display_title)
+        assert_match(/<span class="searchword">/, record.display_title)
       end
     end
   end

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -209,7 +209,7 @@ class SearchTest < Test::Unit::TestCase
       assert_not_nil search.records
       assert((not search.records.empty?))
       search.records.each do |record|
-        assert(/<span class="searchword">/ === record.display_title)
+        assert_match(/(&lt;|<)span class="searchword"(&gt;|>)/, record.display_title)
       end
     end
   end

--- a/test/vcr_cassettes/search_primo_central.yml
+++ b/test/vcr_cassettes/search_primo_central.yml
@@ -2,25 +2,27 @@
 http_interactions:
 - request:
     method: post
-    uri: http://onesearch.library.nd.edu/PrimoWebServices/services/searcher
+    uri: http://primo-fe1.library.nd.edu:1701/PrimoWebServices/services/searcher
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="http://onesearch.library.nd.edu/PrimoWebServices/services/searcher"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><searchBrief><request><![CDATA[<searchRequest
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="http://primo-fe1.library.nd.edu:1701/PrimoWebServices/services/searcher"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:searchBrief><request><![CDATA[<searchRequest
         xmlns="http://www.exlibris.com/primo/xsd/wsRequest" xmlns:uic="http://www.exlibris.com/primo/xsd/primoview/uicomponents"><PrimoSearchRequest
         xmlns="http://www.exlibris.com/primo/xsd/search/request"><QueryTerms><BoolOpeator>AND</BoolOpeator><QueryTerm><IndexField>any</IndexField><PrecisionOperator>contains</PrecisionOperator><Value>van
         gogh</Value></QueryTerm></QueryTerms><StartIndex>1</StartIndex><BulkSize>5</BulkSize><DidUMeanEnabled>false</DidUMeanEnabled><Locations><uic:Location
-        type="adaptor" value="primo_central_multiple_fe"/></Locations></PrimoSearchRequest><institution>NDU</institution></searchRequest>]]></request></searchBrief></env:Body></env:Envelope>
+        type="adaptor" value="primo_central_multiple_fe"/></Locations></PrimoSearchRequest><institution>NDU</institution></searchRequest>]]></request></wsdl:searchBrief></env:Body></env:Envelope>
     headers:
       Soapaction:
-      - ! '"searchBrief"'
+      - '"searchBrief"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '1010'
+      - '1025'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - ! '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
   response:
@@ -28,413 +30,396 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Powered-By:
-      - ! 'Servlet 2.4; Tomcat-5.0.28/JBoss-4.0.1 (build: CVSTag=JBoss_4_0_1 date=200412230944)'
+      Server:
+      - Apache-Coyote/1.1
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
       - chunked
       Date:
-      - Wed, 10 Apr 2013 18:24:06 GMT
-      Server:
-      - Apache-Coyote/1.1
+      - Thu, 05 Jun 2014 16:49:32 GMT
     body:
-      encoding: US-ASCII
-      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"
-        xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><soapenv:Body><searchBriefResponse
-        soapenv:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><searchBriefReturn
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"
+        xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><soapenv:Body><ns1:searchBriefResponse
+        soapenv:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:ns1=\"http://primo-fe1.library.nd.edu:1701/PrimoWebServices/services/searcher\"><searchBriefReturn
         xsi:type=\"soapenc:string\" xmlns:soapenc=\"http://schemas.xmlsoap.org/soap/encoding/\">&lt;sear:SEGMENTS
-        xmlns:prim=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;
-        xmlns:sear=&quot;http://www.exlibrisgroup.com/xsd/jaguar/search&quot;&gt;\n
-        \ &lt;sear:JAGROOT&gt;\n    &lt;sear:RESULT&gt;\n      &lt;sear:FACETLIST
-        ACCURATE_COUNTERS=&quot;true&quot;&gt;\n        &lt;sear:FACET COUNT=&quot;20&quot;
-        NAME=&quot;creator&quot;&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;2&quot;
-        KEY=&quot;Tian, He&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;3&quot;
-        KEY=&quot;Radepont, Marie&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;11&quot;
-        KEY=&quot;Potter, Polyxeni&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;2&quot;
-        KEY=&quot;Gomes, Jos&#xE9;-eduardo&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;6&quot; KEY=&quot;Janssens, K&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;3&quot; KEY=&quot;Cotte, M&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;3&quot; KEY=&quot;Monico, Letizia&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;5&quot; KEY=&quot;Van Der Snickt, Geert&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;2&quot; KEY=&quot;Vanmeert, Frederik&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;3&quot; KEY=&quot;Miliani, Costanza&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;2&quot; KEY=&quot;Verbeeck, Johan&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;5&quot; KEY=&quot;Hendriks, Ella&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;6&quot; KEY=&quot;Cotte, Marine&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;9&quot; KEY=&quot;Janssens, Koen&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;3&quot; KEY=&quot;Yang, Yingzi&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;2&quot; KEY=&quot;Brunetti, Brunetto Giovanni&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;2&quot; KEY=&quot;Brunetti, BG&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;6&quot; KEY=&quot;Dik, Joris&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;3&quot; KEY=&quot;Van Der Loeff, Luuk&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;14&quot; KEY=&quot;Griessen, R&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
-        \       &lt;sear:FACET COUNT=&quot;15&quot; NAME=&quot;lang&quot;&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;1&quot; KEY=&quot;hun&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;172&quot; KEY=&quot;ger&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;7&quot; KEY=&quot;por&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;146&quot; KEY=&quot;fre&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;1&quot; KEY=&quot;heb&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;2&quot; KEY=&quot;rum&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;1&quot; KEY=&quot;nor&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;2&quot; KEY=&quot;dan&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;1&quot; KEY=&quot;rus&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;44&quot; KEY=&quot;dut&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;3&quot; KEY=&quot;ita&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;1&quot; KEY=&quot;chi&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;2&quot; KEY=&quot;pol&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;4182&quot; KEY=&quot;eng&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;35&quot; KEY=&quot;spa&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
-        \       &lt;sear:FACET COUNT=&quot;10&quot; NAME=&quot;rtype&quot;&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;145&quot; KEY=&quot;books&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;620&quot; KEY=&quot;reviews&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;4&quot; KEY=&quot;other&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;51&quot; KEY=&quot;dissertations&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;5095&quot; KEY=&quot;articles&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;461&quot; KEY=&quot;text_resources&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;291&quot; KEY=&quot;conference_proceedings&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;1&quot; KEY=&quot;websites&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;1&quot; KEY=&quot;media&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;394&quot; KEY=&quot;newspaper_articles&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
-        \       &lt;sear:FACET COUNT=&quot;20&quot; NAME=&quot;topic&quot;&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;18&quot; KEY=&quot;Body Patterning&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;72&quot; KEY=&quot;Artists&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;112&quot; KEY=&quot;Literature&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;85&quot; KEY=&quot;Famous Persons&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;21&quot; KEY=&quot;Brain&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;5&quot; KEY=&quot;Meniere Disease&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;43&quot; KEY=&quot;Museums&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;12&quot; KEY=&quot;Suicide&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;16&quot; KEY=&quot;Wnt Proteins&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;39&quot; KEY=&quot;Van Gogh&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;65&quot; KEY=&quot;Creativity&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;40&quot; KEY=&quot;Membrane Proteins&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;10&quot; KEY=&quot;Vincent Van Gogh&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;13&quot; KEY=&quot;Nerve Tissue Proteins&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;11&quot; KEY=&quot;About The Cover&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;157&quot; KEY=&quot;Art&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;55&quot; KEY=&quot;Cell Polarity&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;12&quot; KEY=&quot;Universities And Colleges&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;66&quot; KEY=&quot;Paintings&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;30&quot; KEY=&quot;Drosophila Proteins&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
-        \       &lt;sear:FACET COUNT=&quot;2&quot; NAME=&quot;tlevel&quot;&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;4546&quot; KEY=&quot;online_resources&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;4902&quot; KEY=&quot;peer_reviewed&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
-        \       &lt;sear:FACET COUNT=&quot;8&quot; NAME=&quot;pfilter&quot;&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;149&quot; KEY=&quot;books&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;620&quot; KEY=&quot;reviews&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;51&quot; KEY=&quot;dissertations&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;5458&quot; KEY=&quot;articles&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;1&quot; KEY=&quot;audio_video&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;291&quot; KEY=&quot;conference_proceedings&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;1&quot; KEY=&quot;websites&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;394&quot; KEY=&quot;newspaper_articles&quot;/&gt;\n
-        \       &lt;/sear:FACET&gt;\n        &lt;sear:FACET COUNT=&quot;70&quot; NAME=&quot;creationdate&quot;&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;464&quot; KEY=&quot;2008&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;392&quot; KEY=&quot;2009&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;387&quot; KEY=&quot;2006&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;372&quot; KEY=&quot;2007&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;204&quot; KEY=&quot;2004&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;308&quot; KEY=&quot;2005&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;263&quot; KEY=&quot;2002&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;218&quot; KEY=&quot;2003&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;45&quot; KEY=&quot;1930&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;19&quot; KEY=&quot;1970&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;24&quot; KEY=&quot;1971&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;36&quot; KEY=&quot;1972&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;22&quot; KEY=&quot;1973&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;24&quot; KEY=&quot;1974&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;28&quot; KEY=&quot;1975&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;39&quot; KEY=&quot;1976&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;481&quot; KEY=&quot;2012&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;33&quot; KEY=&quot;1977&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;343&quot; KEY=&quot;2011&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;31&quot; KEY=&quot;1978&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;396&quot; KEY=&quot;2010&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;28&quot; KEY=&quot;1979&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;229&quot; KEY=&quot;2013&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;13&quot; KEY=&quot;1900&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;102&quot; KEY=&quot;1990&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;56&quot; KEY=&quot;1940&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;29&quot; KEY=&quot;1982&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;55&quot; KEY=&quot;1983&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;3&quot; KEY=&quot;1&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;34&quot; KEY=&quot;1980&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;38&quot; KEY=&quot;1981&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;66&quot; KEY=&quot;1986&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;79&quot; KEY=&quot;1987&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;53&quot; KEY=&quot;1984&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;55&quot; KEY=&quot;1985&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;73&quot; KEY=&quot;1988&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;75&quot; KEY=&quot;1989&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;3&quot; KEY=&quot;1910&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;11&quot; KEY=&quot;1959&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;10&quot; KEY=&quot;1958&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;6&quot; KEY=&quot;1957&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;6&quot; KEY=&quot;1956&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;3&quot; KEY=&quot;1955&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;4&quot; KEY=&quot;1954&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;10&quot; KEY=&quot;1953&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;8&quot; KEY=&quot;1952&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;6&quot; KEY=&quot;1951&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;57&quot; KEY=&quot;1950&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;107&quot; KEY=&quot;1995&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;121&quot; KEY=&quot;1996&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;138&quot; KEY=&quot;1997&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;135&quot; KEY=&quot;1998&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;144&quot; KEY=&quot;1991&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;104&quot; KEY=&quot;1992&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;104&quot; KEY=&quot;1993&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;80&quot; KEY=&quot;1994&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;122&quot; KEY=&quot;1999&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;10&quot; KEY=&quot;1920&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;14&quot; KEY=&quot;1967&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;21&quot; KEY=&quot;1966&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;12&quot; KEY=&quot;1969&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;20&quot; KEY=&quot;1968&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;16&quot; KEY=&quot;1963&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;18&quot; KEY=&quot;1962&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;9&quot; KEY=&quot;1965&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;14&quot; KEY=&quot;1964&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;15&quot; KEY=&quot;1961&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;8&quot; KEY=&quot;1960&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;160&quot; KEY=&quot;2001&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;165&quot; KEY=&quot;2000&quot;/&gt;\n
-        \       &lt;/sear:FACET&gt;\n        &lt;sear:FACET COUNT=&quot;20&quot; NAME=&quot;domain&quot;&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;6&quot; KEY=&quot;Energy Citations
-        Database (OSTI)&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;226&quot;
-        KEY=&quot;Cambridge Journals (Cambridge University Press)&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;17&quot; KEY=&quot;IEEE Periodicals&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;11&quot; KEY=&quot;SwePub (National Library of Sweden)&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;1&quot; KEY=&quot;Jazz Music Library
-        (Alexander Street Press)&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;815&quot;
-        KEY=&quot;Taylor &amp;amp; Francis Online - Journals&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;55&quot; KEY=&quot;Informit Humanities &amp;amp; Social Sciences
-        (RMIT)&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;19&quot; KEY=&quot;PLoS&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;470&quot; KEY=&quot;Project MUSE&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;361&quot; KEY=&quot;Arts &amp;amp;
-        Sciences (JSTOR)&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;1559&quot;
-        KEY=&quot;SciVerse ScienceDirect (Elsevier)&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;525&quot; KEY=&quot;SpringerLink&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;133&quot; KEY=&quot;Duke University Press Journals Online&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;720&quot; KEY=&quot;MEDLINE (NLM)&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;104&quot; KEY=&quot;ACM Digital
-        Library&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;35&quot; KEY=&quot;Directory
-        of Open Access Journals (DOAJ)&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;6&quot; KEY=&quot;RACO&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;8&quot; KEY=&quot;Ireland (JSTOR)&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;80&quot; KEY=&quot;PMC (PubMed Central)&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;21&quot; KEY=&quot;Maney Publishing (IngentaConnect)&quot;/&gt;\n
-        \       &lt;/sear:FACET&gt;\n        &lt;sear:FACET COUNT=&quot;20&quot; NAME=&quot;jtitle&quot;&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;14&quot; KEY=&quot;New Scientist&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;16&quot; KEY=&quot;Emerging Infectious
-        Diseases&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;15&quot;
-        KEY=&quot;Financial Times&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;2&quot;
-        KEY=&quot;Electrochimica Acta&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;1&quot; KEY=&quot;Frontiers Of Neurology And Neuroscience&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;11&quot; KEY=&quot;Applied Physics
-        A&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;2&quot; KEY=&quot;Journal
-        Of Cultural Heritage&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;1&quot;
-        KEY=&quot;the minnesota review&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;20&quot; KEY=&quot;Plos One&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;7&quot; KEY=&quot;Development (cambridge, england)&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;17&quot; KEY=&quot;International
-        Herald Tribune&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;4&quot;
-        KEY=&quot;Neuroscience Letters&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;43&quot; KEY=&quot;Developmental Biology&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;6&quot; KEY=&quot;Analytical Chemistry&quot;/&gt;\n          &lt;sear:FACET_VALUES
-        VALUE=&quot;9&quot; KEY=&quot;Jama : The Journal Of The American Medical Association&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;12&quot; KEY=&quot;Nederlands
-        Tijdschrift Voor Geneeskunde&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;2&quot;
-        KEY=&quot;Proceedings Of The National Academy Of Sciences Of The United States
-        Of America&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;57&quot;
-        KEY=&quot;Telegraph Online&quot;/&gt;\n          &lt;sear:FACET_VALUES VALUE=&quot;2&quot;
-        KEY=&quot;European Annals Of Otorhinolaryngology, Head And Neck Diseases&quot;/&gt;\n
-        \         &lt;sear:FACET_VALUES VALUE=&quot;2&quot; KEY=&quot;Journal Of Adult
-        Development&quot;/&gt;\n        &lt;/sear:FACET&gt;\n      &lt;/sear:FACETLIST&gt;\n
-        \     &lt;sear:DOCSET TOTAL_TIME=&quot;114&quot; LASTHIT=&quot;5&quot; FIRSTHIT=&quot;1&quot;
-        TOTALHITS=&quot;6781&quot; HIT_TIME=&quot;59&quot;&gt;\n        &lt;sear:DOC
-        LOCAL=&quot;false&quot; SEARCH_ENGINE_TYPE=&quot;Primo Central Search Engine&quot;
-        SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; NO=&quot;1&quot; RANK=&quot;0.42358816&quot;
-        ID=&quot;402844075&quot;&gt;\n          &lt;prim:PrimoNMBib&gt;\n            &lt;prim:record&gt;\n
-        \             &lt;prim:control&gt;\n                &lt;prim:sourcerecordid&gt;S0262-4079(12)60794-5&lt;/prim:sourcerecordid&gt;\n
-        \               &lt;prim:sourceid&gt;sciversesciencedirect_elsevier&lt;/prim:sourceid&gt;\n
-        \               &lt;prim:recordid&gt;TN_sciversesciencedirect_elsevierS0262-4079(12)60794-5&lt;/prim:recordid&gt;\n
-        \               &lt;prim:sourcesystem&gt;Other&lt;/prim:sourcesystem&gt;\n
-        \             &lt;/prim:control&gt;\n              &lt;prim:display&gt;\n
-        \               &lt;prim:type&gt;article&lt;/prim:type&gt;\n                &lt;prim:title&gt;Disputed
-        painting revealed as a Van Gogh&lt;/prim:title&gt;\n                &lt;prim:ispartof&gt;New
-        Scientist, 2012, Vol.213(2858), pp.7-7&lt;/prim:ispartof&gt;\n                &lt;prim:identifier&gt;&amp;lt;b&gt;ISSN:
-        &amp;lt;/b&gt;0262-4079 ; &amp;lt;b&gt;DOI: &amp;lt;/b&gt;10.1016/S0262-4079(12)60794-5&lt;/prim:identifier&gt;\n
-        \               &lt;prim:description&gt;High-energy radiation reveals that
-        a painting of a bouquet considered too flowery to be done by Van Gogh was
-        actually his&lt;/prim:description&gt;\n                &lt;prim:language&gt;eng&lt;/prim:language&gt;\n
-        \               &lt;prim:source&gt;SciVerse ScienceDirect Journals&lt;/prim:source&gt;\n
-        \             &lt;/prim:display&gt;\n              &lt;prim:links&gt;\n                &lt;prim:openurl&gt;$$Topenurl_article&lt;/prim:openurl&gt;\n
-        \               &lt;prim:backlink&gt;$$Uhttp://dx.doi.org/10.1016/S0262-4079(12)60794-5$$EView_record_in_SciVerse_ScienceDirect
-        _Journals_(Elsevier)&lt;/prim:backlink&gt;\n                &lt;prim:openurlfulltext&gt;$$Topenurlfull_article&lt;/prim:openurlfulltext&gt;\n
-        \             &lt;/prim:links&gt;\n              &lt;prim:search&gt;\n                &lt;prim:title&gt;Disputed
-        painting revealed as a Van Gogh&lt;/prim:title&gt;\n                &lt;prim:description&gt;High-energy
-        radiation reveals that a painting of a bouquet considered too flowery to be
-        done by Van Gogh was actually his&lt;/prim:description&gt;\n                &lt;prim:general&gt;English&lt;/prim:general&gt;\n
-        \               &lt;prim:general&gt;10.1016/S0262-4079(12)60794-5&lt;/prim:general&gt;\n
-        \               &lt;prim:general&gt;SciVerse ScienceDirect Journals&lt;/prim:general&gt;\n
-        \               &lt;prim:sourceid&gt;sciversesciencedirect_elsevier&lt;/prim:sourceid&gt;\n
-        \               &lt;prim:recordid&gt;sciversesciencedirect_elsevierS0262-4079(12)60794-5&lt;/prim:recordid&gt;\n
-        \               &lt;prim:issn&gt;02624079&lt;/prim:issn&gt;\n                &lt;prim:issn&gt;0262-4079&lt;/prim:issn&gt;\n
-        \               &lt;prim:rsrctype&gt;article&lt;/prim:rsrctype&gt;\n                &lt;prim:creationdate&gt;31
-        March 2012&lt;/prim:creationdate&gt;\n                &lt;prim:creationdate&gt;2012&lt;/prim:creationdate&gt;\n
-        \               &lt;prim:addtitle&gt;New Scientist&lt;/prim:addtitle&gt;\n
-        \               &lt;prim:searchscope&gt;sciversesciencedirect_elsevier&lt;/prim:searchscope&gt;\n
-        \               &lt;prim:searchscope&gt;elsevier_sciencedirect&lt;/prim:searchscope&gt;\n
-        \               &lt;prim:scope&gt;sciversesciencedirect_elsevier&lt;/prim:scope&gt;\n
-        \               &lt;prim:scope&gt;elsevier_sciencedirect&lt;/prim:scope&gt;\n
-        \             &lt;/prim:search&gt;\n              &lt;prim:sort&gt;\n                &lt;prim:title&gt;Disputed
-        painting revealed as a Van Gogh&lt;/prim:title&gt;\n                &lt;prim:creationdate&gt;20120331&lt;/prim:creationdate&gt;\n
-        \             &lt;/prim:sort&gt;\n              &lt;prim:facets&gt;\n                &lt;prim:language&gt;eng&lt;/prim:language&gt;\n
-        \               &lt;prim:creationdate&gt;2012&lt;/prim:creationdate&gt;\n
-        \               &lt;prim:collection&gt;ScienceDirect (Elsevier)&lt;/prim:collection&gt;\n
-        \               &lt;prim:collection&gt;SciVerse ScienceDirect (Elsevier)&lt;/prim:collection&gt;\n
-        \               &lt;prim:prefilter&gt;articles&lt;/prim:prefilter&gt;\n                &lt;prim:rsrctype&gt;articles&lt;/prim:rsrctype&gt;\n
-        \               &lt;prim:jtitle&gt;New Scientist&lt;/prim:jtitle&gt;\n                &lt;prim:frbrgroupid&gt;485703486&lt;/prim:frbrgroupid&gt;\n
-        \               &lt;prim:frbrtype&gt;6&lt;/prim:frbrtype&gt;\n              &lt;/prim:facets&gt;\n
-        \             &lt;prim:frbr&gt;\n                &lt;prim:t&gt;2&lt;/prim:t&gt;\n
-        \               &lt;prim:k1&gt;2012&lt;/prim:k1&gt;\n                &lt;prim:k2&gt;02624079&lt;/prim:k2&gt;\n
-        \               &lt;prim:k3&gt;10.1016/S0262-4079(12)60794-5&lt;/prim:k3&gt;\n
-        \               &lt;prim:k4&gt;213&lt;/prim:k4&gt;\n                &lt;prim:k5&gt;2858&lt;/prim:k5&gt;\n
-        \               &lt;prim:k6&gt;7&lt;/prim:k6&gt;\n                &lt;prim:k7&gt;new
-        scientist&lt;/prim:k7&gt;\n                &lt;prim:k8&gt;disputed painting
-        revealed as van gogh&lt;/prim:k8&gt;\n                &lt;prim:k9&gt;disputedpaintingrevengogh&lt;/prim:k9&gt;\n
-        \               &lt;prim:k12&gt;disputedpaintingrevealeda&lt;/prim:k12&gt;\n
-        \             &lt;/prim:frbr&gt;\n              &lt;prim:delivery&gt;\n                &lt;prim:delcategory&gt;Remote
-        Search Resource&lt;/prim:delcategory&gt;\n                &lt;prim:fulltext&gt;fulltext&lt;/prim:fulltext&gt;\n
-        \             &lt;/prim:delivery&gt;\n              &lt;prim:ranking&gt;\n
-        \               &lt;prim:booster1&gt;1&lt;/prim:booster1&gt;\n                &lt;prim:booster2&gt;1&lt;/prim:booster2&gt;\n
-        \               &lt;prim:pcg_type&gt;publisher&lt;/prim:pcg_type&gt;\n              &lt;/prim:ranking&gt;\n
-        \             &lt;prim:addata&gt;\n                &lt;prim:atitle&gt;Disputed
-        painting revealed as a Van Gogh&lt;/prim:atitle&gt;\n                &lt;prim:jtitle&gt;New
-        Scientist&lt;/prim:jtitle&gt;\n                &lt;prim:date&gt;20120331&lt;/prim:date&gt;\n
-        \               &lt;prim:risdate&gt;20120331&lt;/prim:risdate&gt;\n                &lt;prim:volume&gt;213&lt;/prim:volume&gt;\n
-        \               &lt;prim:issue&gt;2858&lt;/prim:issue&gt;\n                &lt;prim:spage&gt;7&lt;/prim:spage&gt;\n
-        \               &lt;prim:epage&gt;7&lt;/prim:epage&gt;\n                &lt;prim:pages&gt;7-7&lt;/prim:pages&gt;\n
-        \               &lt;prim:issn&gt;0262-4079&lt;/prim:issn&gt;\n                &lt;prim:genre&gt;article&lt;/prim:genre&gt;\n
-        \               &lt;prim:ristype&gt;JOUR&lt;/prim:ristype&gt;\n                &lt;prim:abstract&gt;High-energy
-        radiation reveals that a painting of a bouquet considered too flowery to be
-        done by Van Gogh was actually his&lt;/prim:abstract&gt;\n                &lt;prim:doi&gt;10.1016/S0262-4079(12)60794-5&lt;/prim:doi&gt;\n
-        \             &lt;/prim:addata&gt;\n            &lt;/prim:record&gt;\n          &lt;/prim:PrimoNMBib&gt;\n
-        \         &lt;sear:GETIT GetIt2=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&quot;
-        GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&quot;
-        deliveryCategory=&quot;Remote Search Resource&quot;/&gt;\n          &lt;sear:LINKS&gt;\n
-        \           &lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;rft.jtitle=New%20Scientist&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20120331&amp;rft.volume=213&amp;rft.issue=2858&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=7&amp;rft.epage=7&amp;rft.pages=7-7&amp;rft.artnum=&amp;rft.issn=0262-4079&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&lt;/sciversesciencedirect_elsevier&gt;&amp;rft_id=info:oai/]]&gt;&lt;/sear:openurl&gt;\n
-        \           &lt;sear:backlink&gt;http://dx.doi.org/10.1016/S0262-4079(12)60794-5&lt;/sear:backlink&gt;\n
-        \           &lt;sear:thumbnail/&gt;\n            &lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;rft.jtitle=New%20Scientist&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20120331&amp;rft.volume=213&amp;rft.issue=2858&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=7&amp;rft.epage=7&amp;rft.pages=7-7&amp;rft.artnum=&amp;rft.issn=0262-4079&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&lt;/sciversesciencedirect_elsevier&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article]]&gt;&lt;/sear:openurlfulltext&gt;\n
-        \         &lt;/sear:LINKS&gt;\n        &lt;/sear:DOC&gt;\n        &lt;sear:DOC
-        LOCAL=&quot;false&quot; SEARCH_ENGINE_TYPE=&quot;Primo Central Search Engine&quot;
-        SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; NO=&quot;2&quot; RANK=&quot;0.2986234&quot;
-        ID=&quot;145966088&quot;&gt;\n          &lt;PrimoNMBib xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;\n
-        \           &lt;record&gt;\n              &lt;control&gt;\n                &lt;sourcerecordid&gt;S0262-4079(11)60359-X&lt;/sourcerecordid&gt;\n
-        \               &lt;sourceid&gt;sciversesciencedirect_elsevier&lt;/sourceid&gt;\n
-        \               &lt;recordid&gt;TN_sciversesciencedirect_elsevierS0262-4079(11)60359-X&lt;/recordid&gt;\n
-        \               &lt;sourcesystem&gt;Other&lt;/sourcesystem&gt;\n              &lt;/control&gt;\n
-        \             &lt;display&gt;\n                &lt;type&gt;article&lt;/type&gt;\n
-        \               &lt;title&gt;X-rays show why van Gogh's yellows have darkened&lt;/title&gt;\n
-        \               &lt;ispartof&gt;New Scientist, 2011, Vol.209(2800), pp.5-5&lt;/ispartof&gt;\n
-        \               &lt;identifier&gt;&amp;lt;b&gt;ISSN: &amp;lt;/b&gt;0262-4079
-        ; &amp;lt;b&gt;DOI: &amp;lt;/b&gt;10.1016/S0262-4079(11)60359-X&lt;/identifier&gt;\n
-        \               &lt;description&gt;Van Gogh may have made his paint last longer
-        by adding barium sulphate, X-ray synchrotron reveals &#x2013; an addition
-        that has made the paint darken&lt;/description&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
-        \               &lt;source&gt;SciVerse ScienceDirect Journals&lt;/source&gt;\n
+        xmlns:sear=&quot;http://www.exlibrisgroup.com/xsd/jaguar/search&quot;&gt;&lt;sear:JAGROOT&gt;\n
+        \   &lt;sear:RESULT&gt;\n      &lt;sear:QUERYTRANSFORMS/&gt;\n      &lt;sear:FACETLIST
+        ACCURATE_COUNTERS=&quot;true&quot;&gt;\n        &lt;sear:FACET NAME=&quot;creator&quot;
+        COUNT=&quot;20&quot;&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Kooij,
+        E.S.&quot; VALUE=&quot;9&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Tian,
+        He&quot; VALUE=&quot;6&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Radepont,
+        Marie&quot; VALUE=&quot;7&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Russell,
+        John&quot; VALUE=&quot;103&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Kimmelman,
+        Michael&quot; VALUE=&quot;93&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Gogh,
+        Vincent Van&quot; VALUE=&quot;18&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Arnold, Wilfred Niels&quot; VALUE=&quot;15&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Koeman, N.J.&quot; VALUE=&quot;10&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Monico, Letizia&quot; VALUE=&quot;9&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Van Der Snickt, Geert&quot; VALUE=&quot;9&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Vogel, Carol&quot; VALUE=&quot;167&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Miliani, Costanza&quot; VALUE=&quot;7&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Hendriks, Ella&quot; VALUE=&quot;8&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Cotte, Marine&quot; VALUE=&quot;10&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Janssens, Koen&quot; VALUE=&quot;15&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Reif, Rita&quot; VALUE=&quot;80&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Griessen, R.&quot; VALUE=&quot;20&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Dik, Joris&quot; VALUE=&quot;9&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Soth, Lauren&quot; VALUE=&quot;9&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Bailey, Martin&quot; VALUE=&quot;29&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
+        \       &lt;sear:FACET NAME=&quot;lang&quot; COUNT=&quot;20&quot;&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;cat&quot; VALUE=&quot;10&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;hun&quot; VALUE=&quot;1&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;ger&quot; VALUE=&quot;326&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;por&quot; VALUE=&quot;29&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;fre&quot; VALUE=&quot;199&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;heb&quot; VALUE=&quot;3&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;rum&quot; VALUE=&quot;2&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;swe&quot; VALUE=&quot;6&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;kor&quot; VALUE=&quot;20&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;und&quot; VALUE=&quot;8&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;nor&quot; VALUE=&quot;1&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;dan&quot; VALUE=&quot;2&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;rus&quot; VALUE=&quot;1&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;dut&quot; VALUE=&quot;59&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;ita&quot; VALUE=&quot;22&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;chi&quot; VALUE=&quot;118&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;pol&quot; VALUE=&quot;2&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;glg&quot; VALUE=&quot;2&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;eng&quot; VALUE=&quot;24612&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;spa&quot; VALUE=&quot;161&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
+        \       &lt;sear:FACET NAME=&quot;rtype&quot; COUNT=&quot;14&quot;&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;books&quot; VALUE=&quot;108&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;reviews&quot; VALUE=&quot;3136&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;journals&quot; VALUE=&quot;2&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;articles&quot; VALUE=&quot;16253&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;other&quot; VALUE=&quot;4&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;text_resources&quot; VALUE=&quot;641&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;websites&quot; VALUE=&quot;21&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;newspaper_articles&quot; VALUE=&quot;14004&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;reference_entrys&quot; VALUE=&quot;301&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;research_datasets&quot; VALUE=&quot;30&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Dissertations&quot; VALUE=&quot;82&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;conference_proceedings&quot; VALUE=&quot;430&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;images&quot; VALUE=&quot;13&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;media&quot; VALUE=&quot;161&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
+        \       &lt;sear:FACET NAME=&quot;topic&quot; COUNT=&quot;19&quot;&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Artists&quot; VALUE=&quot;712&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Art Exhibitions&quot; VALUE=&quot;474&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Dutch Painters&quot; VALUE=&quot;58&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Modern Art&quot; VALUE=&quot;209&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Bipolar Disorder&quot; VALUE=&quot;53&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Gogh, Vincent Van&quot; VALUE=&quot;123&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Famous Persons&quot; VALUE=&quot;100&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Museums&quot; VALUE=&quot;595&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Creativity&quot; VALUE=&quot;145&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Art Auctions&quot; VALUE=&quot;72&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Art Museums&quot; VALUE=&quot;393&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Art&quot; VALUE=&quot;547&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Painters (Artists)&quot; VALUE=&quot;624&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot; Van Gogh&quot; VALUE=&quot;82&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Art Thefts&quot; VALUE=&quot;119&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Epilepsy&quot; VALUE=&quot;56&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Mental Disorders&quot; VALUE=&quot;62&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Paintings&quot; VALUE=&quot;87&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Painting (Art)&quot; VALUE=&quot;556&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
+        \       &lt;sear:FACET NAME=&quot;tlevel&quot; COUNT=&quot;2&quot;&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;online_resources&quot; VALUE=&quot;27696&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;peer_reviewed&quot; VALUE=&quot;8186&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
+        \       &lt;sear:FACET NAME=&quot;pfilter&quot; COUNT=&quot;12&quot;&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;books&quot; VALUE=&quot;178&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;reviews&quot; VALUE=&quot;3136&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;reference_entrys&quot; VALUE=&quot;301&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;journals&quot; VALUE=&quot;2&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;articles&quot; VALUE=&quot;16633&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;research_datasets&quot; VALUE=&quot;30&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;Dissertations&quot; VALUE=&quot;82&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;audio_video&quot; VALUE=&quot;161&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;images&quot; VALUE=&quot;13&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;conference_proceedings&quot; VALUE=&quot;430&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;websites&quot; VALUE=&quot;21&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;newspaper_articles&quot; VALUE=&quot;14004&quot;/&gt;\n
+        \       &lt;/sear:FACET&gt;\n        &lt;sear:FACET NAME=&quot;creationdate&quot;
+        COUNT=&quot;76&quot;&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2008&quot;
+        VALUE=&quot;1999&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2009&quot;
+        VALUE=&quot;1780&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2006&quot;
+        VALUE=&quot;2146&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2007&quot;
+        VALUE=&quot;2081&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2004&quot;
+        VALUE=&quot;2062&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2005&quot;
+        VALUE=&quot;2124&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2002&quot;
+        VALUE=&quot;1428&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2003&quot;
+        VALUE=&quot;1738&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1930&quot;
+        VALUE=&quot;72&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1970&quot;
+        VALUE=&quot;36&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1971&quot;
+        VALUE=&quot;41&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1972&quot;
+        VALUE=&quot;52&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1973&quot;
+        VALUE=&quot;38&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1974&quot;
+        VALUE=&quot;35&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1975&quot;
+        VALUE=&quot;44&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1976&quot;
+        VALUE=&quot;56&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1977&quot;
+        VALUE=&quot;52&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2012&quot;
+        VALUE=&quot;1650&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1978&quot;
+        VALUE=&quot;43&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2011&quot;
+        VALUE=&quot;1478&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1979&quot;
+        VALUE=&quot;54&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2010&quot;
+        VALUE=&quot;2328&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2013&quot;
+        VALUE=&quot;993&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2014&quot;
+        VALUE=&quot;590&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1900&quot;
+        VALUE=&quot;13&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1990&quot;
+        VALUE=&quot;600&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1940&quot;
+        VALUE=&quot;136&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;500&quot;
+        VALUE=&quot;1&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1982&quot;
+        VALUE=&quot;57&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1983&quot;
+        VALUE=&quot;98&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1&quot;
+        VALUE=&quot;8&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1980&quot;
+        VALUE=&quot;66&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1981&quot;
+        VALUE=&quot;83&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1986&quot;
+        VALUE=&quot;222&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1987&quot;
+        VALUE=&quot;349&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1984&quot;
+        VALUE=&quot;129&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1985&quot;
+        VALUE=&quot;224&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1988&quot;
+        VALUE=&quot;297&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1989&quot;
+        VALUE=&quot;290&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1910&quot;
+        VALUE=&quot;4&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1600&quot;
+        VALUE=&quot;4&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1959&quot;
+        VALUE=&quot;20&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1958&quot;
+        VALUE=&quot;23&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1957&quot;
+        VALUE=&quot;29&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1956&quot;
+        VALUE=&quot;32&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1955&quot;
+        VALUE=&quot;20&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1954&quot;
+        VALUE=&quot;18&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1953&quot;
+        VALUE=&quot;31&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1952&quot;
+        VALUE=&quot;21&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1951&quot;
+        VALUE=&quot;20&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1950&quot;
+        VALUE=&quot;157&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1995&quot;
+        VALUE=&quot;466&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1996&quot;
+        VALUE=&quot;512&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1997&quot;
+        VALUE=&quot;613&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1998&quot;
+        VALUE=&quot;964&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1991&quot;
+        VALUE=&quot;441&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1500&quot;
+        VALUE=&quot;6&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1992&quot;
+        VALUE=&quot;420&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1993&quot;
+        VALUE=&quot;452&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1994&quot;
+        VALUE=&quot;424&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1800&quot;
+        VALUE=&quot;4&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1700&quot;
+        VALUE=&quot;10&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1999&quot;
+        VALUE=&quot;1042&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1920&quot;
+        VALUE=&quot;18&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1967&quot;
+        VALUE=&quot;26&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1966&quot;
+        VALUE=&quot;33&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1969&quot;
+        VALUE=&quot;23&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1968&quot;
+        VALUE=&quot;32&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1963&quot;
+        VALUE=&quot;30&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1962&quot;
+        VALUE=&quot;31&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1965&quot;
+        VALUE=&quot;19&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1964&quot;
+        VALUE=&quot;37&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1961&quot;
+        VALUE=&quot;35&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;1960&quot;
+        VALUE=&quot;24&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2001&quot;
+        VALUE=&quot;1321&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;2000&quot;
+        VALUE=&quot;1246&quot;/&gt;\n        &lt;/sear:FACET&gt;\n        &lt;sear:FACET
+        NAME=&quot;domain&quot; COUNT=&quot;20&quot;&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Nature Publishing Group (CrossRef)&quot; VALUE=&quot;47&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;Taylor &amp;amp; Francis Online
+        - Journals&quot; VALUE=&quot;2012&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Wiley Online Library&quot; VALUE=&quot;120&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;JSTOR&quot; VALUE=&quot;806&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;ERIC (U.S. Dept. of Education)&quot; VALUE=&quot;130&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;Project MUSE&quot; VALUE=&quot;561&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;Dialnet&quot; VALUE=&quot;19&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;SciVerse ScienceDirect (Elsevier)&quot;
+        VALUE=&quot;1650&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;American
+        Medical Association (CrossRef)&quot; VALUE=&quot;13&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Wolters Kluwer - Ovid - Lippincott Williams &amp;amp; Wilkins (CrossRef)&quot;
+        VALUE=&quot;15&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;SpringerLink&quot;
+        VALUE=&quot;413&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Britannica
+        Online Academic Edition&quot; VALUE=&quot;75&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;MEDLINE (NLM)&quot; VALUE=&quot;1087&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Informa - Taylor &amp;amp; Francis (CrossRef)&quot; VALUE=&quot;1671&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;Directory of Open Access Journals
+        (DOAJ)&quot; VALUE=&quot;112&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;NDLTD
+        Union Catalog&quot; VALUE=&quot;66&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;American Chemical Society (CrossRef)&quot; VALUE=&quot;13&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;&#x7EF4;&#x666E;&#x8D44;&#x8BAF;
+        (Chongqing VIP Information Co.)&quot; VALUE=&quot;117&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;KISS (Korean studies Information Service System)&quot; VALUE=&quot;18&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;OneFile (GALE)&quot; VALUE=&quot;26192&quot;/&gt;\n
+        \       &lt;/sear:FACET&gt;\n        &lt;sear:FACET NAME=&quot;jtitle&quot;
+        COUNT=&quot;19&quot;&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;London
+        Evening Standard (London, England)&quot; VALUE=&quot;159&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Jama: The Journal Of The American Medical Association&quot; VALUE=&quot;14&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;PRWeb Newswire&quot; VALUE=&quot;131&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;ARTnews&quot; VALUE=&quot;60&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;The New York Times&quot; VALUE=&quot;2456&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;Nature&quot; VALUE=&quot;29&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;Quotations Book&quot; VALUE=&quot;21&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;Burlington Magazine&quot; VALUE=&quot;92&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;The Times (London, England)&quot;
+        VALUE=&quot;201&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Asia
+        Africa Intelligence Wire&quot; VALUE=&quot;523&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Choice Reviews Online&quot; VALUE=&quot;38&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Time&quot; VALUE=&quot;415&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Newsweek&quot; VALUE=&quot;46&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Analytical Chemistry&quot; VALUE=&quot;12&quot;/&gt;\n          &lt;sear:FACET_VALUES
+        KEY=&quot;Sunday Times (London, England)&quot; VALUE=&quot;184&quot;/&gt;\n
+        \         &lt;sear:FACET_VALUES KEY=&quot;Nederlands Tijdschrift Voor Geneeskunde&quot;
+        VALUE=&quot;12&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Apollo&quot;
+        VALUE=&quot;174&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;School
+        Arts&quot; VALUE=&quot;124&quot;/&gt;\n          &lt;sear:FACET_VALUES KEY=&quot;Arts
+        &amp;amp; Activities&quot; VALUE=&quot;153&quot;/&gt;\n        &lt;/sear:FACET&gt;\n
+        \     &lt;/sear:FACETLIST&gt;\n      &lt;sear:DOCSET HIT_TIME=&quot;84&quot;
+        TOTALHITS=&quot;33912&quot; FIRSTHIT=&quot;1&quot; LASTHIT=&quot;5&quot; TOTAL_TIME=&quot;283&quot;&gt;\n
+        \       &lt;sear:DOC ID=&quot;245124465&quot; RANK=&quot;0.10000001&quot;
+        NO=&quot;1&quot; SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; SEARCH_ENGINE_TYPE=&quot;Primo
+        Central Search Engine&quot; LOCAL=&quot;false&quot;&gt;\n          &lt;PrimoNMBib
+        xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;\n
+        \           &lt;record&gt;\n              &lt;control&gt;\n                &lt;sourcerecordid&gt;10.5860/CHOICE.36-1963&lt;/sourcerecordid&gt;\n
+        \               &lt;sourceid&gt;crossref&lt;/sourceid&gt;\n                &lt;recordid&gt;TN_crossref10.5860/CHOICE.36-1963&lt;/recordid&gt;\n
+        \               &lt;sourceformat&gt;XML&lt;/sourceformat&gt;\n                &lt;sourcesystem&gt;Other&lt;/sourcesystem&gt;\n
+        \             &lt;/control&gt;\n              &lt;display&gt;\n                &lt;type&gt;article&lt;/type&gt;\n
+        \               &lt;title&gt;Van Gogh&lt;/title&gt;\n                &lt;ispartof&gt;Choice
+        Reviews Online, 1998, Vol.36(04), pp.36-1963-36-1963&lt;/ispartof&gt;\n                &lt;identifier&gt;&lt;![CDATA[&lt;b&gt;ISSN:&lt;/b&gt;
+        0009-4978 ; &lt;b&gt;E-ISSN:&lt;/b&gt; 1523-8253 ; &lt;b&gt;DOI:&lt;/b&gt;
+        http://dx.doi.org/10.5860/CHOICE.36-1963]]&gt;&lt;/identifier&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
+        \               &lt;source&gt;CrossRef&lt;/source&gt;\n                &lt;lds40&gt;19981201&lt;/lds40&gt;\n
+        \               &lt;lds41&gt;19981201&lt;/lds41&gt;\n                &lt;lds43&gt;19981201&lt;/lds43&gt;\n
+        \               &lt;lds45&gt;19981201&lt;/lds45&gt;\n                &lt;lds50&gt;peer_reviewed&lt;/lds50&gt;\n
         \             &lt;/display&gt;\n              &lt;links&gt;\n                &lt;openurl&gt;$$Topenurl_article&lt;/openurl&gt;\n
-        \               &lt;backlink&gt;$$Uhttp://dx.doi.org/10.1016/S0262-4079(11)60359-X$$EView_record_in_SciVerse_ScienceDirect
-        _Journals_(Elsevier)&lt;/backlink&gt;\n                &lt;openurlfulltext&gt;$$Topenurlfull_article&lt;/openurlfulltext&gt;\n
-        \             &lt;/links&gt;\n              &lt;search&gt;\n                &lt;title&gt;X-rays
-        show why van Gogh's yellows have darkened&lt;/title&gt;\n                &lt;description&gt;Van
-        Gogh may have made his paint last longer by adding barium sulphate, X-ray
-        synchrotron reveals &#x2013; an addition that has made the paint darken&lt;/description&gt;\n
-        \               &lt;general&gt;English&lt;/general&gt;\n                &lt;general&gt;10.1016/S0262-4079(11)60359-X&lt;/general&gt;\n
-        \               &lt;general&gt;SciVerse ScienceDirect Journals&lt;/general&gt;\n
-        \               &lt;sourceid&gt;sciversesciencedirect_elsevier&lt;/sourceid&gt;\n
-        \               &lt;recordid&gt;sciversesciencedirect_elsevierS0262-4079(11)60359-X&lt;/recordid&gt;\n
-        \               &lt;issn&gt;02624079&lt;/issn&gt;\n                &lt;issn&gt;0262-4079&lt;/issn&gt;\n
-        \               &lt;rsrctype&gt;article&lt;/rsrctype&gt;\n                &lt;creationdate&gt;2011&lt;/creationdate&gt;\n
-        \               &lt;addtitle&gt;New Scientist&lt;/addtitle&gt;\n                &lt;searchscope&gt;sciversesciencedirect_elsevier&lt;/searchscope&gt;\n
-        \               &lt;searchscope&gt;elsevier_sciencedirect&lt;/searchscope&gt;\n
-        \               &lt;scope&gt;sciversesciencedirect_elsevier&lt;/scope&gt;\n
-        \               &lt;scope&gt;elsevier_sciencedirect&lt;/scope&gt;\n              &lt;/search&gt;\n
-        \             &lt;sort&gt;\n                &lt;title&gt;X-rays show why van
-        Gogh's yellows have darkened&lt;/title&gt;\n                &lt;creationdate&gt;20110000&lt;/creationdate&gt;\n
-        \             &lt;/sort&gt;\n              &lt;facets&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
-        \               &lt;creationdate&gt;2011&lt;/creationdate&gt;\n                &lt;collection&gt;ScienceDirect
-        (Elsevier)&lt;/collection&gt;\n                &lt;collection&gt;SciVerse
-        ScienceDirect (Elsevier)&lt;/collection&gt;\n                &lt;prefilter&gt;articles&lt;/prefilter&gt;\n
-        \               &lt;rsrctype&gt;articles&lt;/rsrctype&gt;\n                &lt;jtitle&gt;New
-        Scientist&lt;/jtitle&gt;\n                &lt;frbrgroupid&gt;16083819&lt;/frbrgroupid&gt;\n
-        \               &lt;frbrtype&gt;6&lt;/frbrtype&gt;\n              &lt;/facets&gt;\n
-        \             &lt;frbr&gt;\n                &lt;t&gt;2&lt;/t&gt;\n                &lt;k1&gt;2011&lt;/k1&gt;\n
-        \               &lt;k2&gt;02624079&lt;/k2&gt;\n                &lt;k3&gt;10.1016/S0262-4079(11)60359-X&lt;/k3&gt;\n
-        \               &lt;k4&gt;209&lt;/k4&gt;\n                &lt;k5&gt;2800&lt;/k5&gt;\n
-        \               &lt;k6&gt;5&lt;/k6&gt;\n                &lt;k7&gt;new scientist&lt;/k7&gt;\n
-        \               &lt;k8&gt;x rays show why van gogh apos s yellows have darkened&lt;/k8&gt;\n
-        \               &lt;k9&gt;xraysshowwhyvangoghakened&lt;/k9&gt;\n                &lt;k12&gt;xraysshowwhyvangoghapossy&lt;/k12&gt;\n
-        \             &lt;/frbr&gt;\n              &lt;delivery&gt;\n                &lt;delcategory&gt;Remote
+        \               &lt;openurlfulltext&gt;$$Topenurlfull_article&lt;/openurlfulltext&gt;\n
+        \               &lt;addlink&gt;$$Uhttps://exlibris-pub.s3.amazonaws.com/aboutCrossref.html$$DView
+        CrossRef copyright notice&lt;/addlink&gt;\n              &lt;/links&gt;\n
+        \             &lt;search&gt;\n                &lt;title&gt;Van Gogh&lt;/title&gt;\n
+        \               &lt;general&gt;English&lt;/general&gt;\n                &lt;general&gt;10.5860/CHOICE.36-1963&lt;/general&gt;\n
+        \               &lt;sourceid&gt;crossref&lt;/sourceid&gt;\n                &lt;recordid&gt;crossref10.5860/CHOICE.36-1963&lt;/recordid&gt;\n
+        \               &lt;issn&gt;0009-4978&lt;/issn&gt;\n                &lt;issn&gt;00094978&lt;/issn&gt;\n
+        \               &lt;issn&gt;1523-8253&lt;/issn&gt;\n                &lt;issn&gt;15238253&lt;/issn&gt;\n
+        \               &lt;rsrctype&gt;article&lt;/rsrctype&gt;\n                &lt;creationdate&gt;1998&lt;/creationdate&gt;\n
+        \               &lt;addtitle&gt;Choice Reviews Online&lt;/addtitle&gt;\n                &lt;searchscope&gt;crossref_rest&lt;/searchscope&gt;\n
+        \               &lt;searchscope&gt;CrossRef&lt;/searchscope&gt;\n                &lt;searchscope&gt;Crossref&lt;/searchscope&gt;\n
+        \               &lt;searchscope&gt;crossref&lt;/searchscope&gt;\n                &lt;scope&gt;crossref_rest&lt;/scope&gt;\n
+        \               &lt;scope&gt;CrossRef&lt;/scope&gt;\n                &lt;scope&gt;Crossref&lt;/scope&gt;\n
+        \               &lt;scope&gt;crossref&lt;/scope&gt;\n              &lt;/search&gt;\n
+        \             &lt;sort&gt;\n                &lt;title&gt;Van Gogh&lt;/title&gt;\n
+        \               &lt;creationdate&gt;19981201&lt;/creationdate&gt;\n              &lt;/sort&gt;\n
+        \             &lt;facets&gt;\n                &lt;frbrgroupid&gt;5418720077066216478&lt;/frbrgroupid&gt;\n
+        \               &lt;frbrtype&gt;6&lt;/frbrtype&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
+        \               &lt;creationdate&gt;1998&lt;/creationdate&gt;\n                &lt;prefilter&gt;articles&lt;/prefilter&gt;\n
+        \               &lt;rsrctype&gt;articles&lt;/rsrctype&gt;\n                &lt;jtitle&gt;Choice
+        Reviews Online&lt;/jtitle&gt;\n                &lt;toplevel&gt;peer_reviewed&lt;/toplevel&gt;\n
+        \             &lt;/facets&gt;\n              &lt;frbr&gt;\n                &lt;t&gt;2&lt;/t&gt;\n
+        \               &lt;k1&gt;1998&lt;/k1&gt;\n                &lt;k2&gt;00094978&lt;/k2&gt;\n
+        \               &lt;k2&gt;15238253&lt;/k2&gt;\n                &lt;k3&gt;10.5860/CHOICE.36-1963&lt;/k3&gt;\n
+        \               &lt;k4&gt;36&lt;/k4&gt;\n                &lt;k5&gt;04&lt;/k5&gt;\n
+        \               &lt;k6&gt;36&lt;/k6&gt;\n                &lt;k7&gt;choice
+        reviews online&lt;/k7&gt;\n                &lt;k8&gt;van gogh&lt;/k8&gt;\n
+        \               &lt;k9&gt;vangogh&lt;/k9&gt;\n              &lt;/frbr&gt;\n
+        \             &lt;delivery&gt;\n                &lt;delcategory&gt;Remote
         Search Resource&lt;/delcategory&gt;\n                &lt;fulltext&gt;fulltext&lt;/fulltext&gt;\n
         \             &lt;/delivery&gt;\n              &lt;ranking&gt;\n                &lt;booster1&gt;1&lt;/booster1&gt;\n
-        \               &lt;booster2&gt;1&lt;/booster2&gt;\n                &lt;pcg_type&gt;publisher&lt;/pcg_type&gt;\n
-        \             &lt;/ranking&gt;\n              &lt;addata&gt;\n                &lt;atitle&gt;X-rays
-        show why van Gogh's yellows have darkened&lt;/atitle&gt;\n                &lt;jtitle&gt;New
-        Scientist&lt;/jtitle&gt;\n                &lt;date&gt;2011&lt;/date&gt;\n
-        \               &lt;risdate&gt;2011&lt;/risdate&gt;\n                &lt;volume&gt;209&lt;/volume&gt;\n
-        \               &lt;issue&gt;2800&lt;/issue&gt;\n                &lt;spage&gt;5&lt;/spage&gt;\n
-        \               &lt;epage&gt;5&lt;/epage&gt;\n                &lt;pages&gt;5-5&lt;/pages&gt;\n
-        \               &lt;issn&gt;0262-4079&lt;/issn&gt;\n                &lt;genre&gt;article&lt;/genre&gt;\n
-        \               &lt;ristype&gt;JOUR&lt;/ristype&gt;\n                &lt;abstract&gt;Van
-        Gogh may have made his paint last longer by adding barium sulphate, X-ray
-        synchrotron reveals &#x2013; an addition that has made the paint darken&lt;/abstract&gt;\n
-        \               &lt;doi&gt;10.1016/S0262-4079(11)60359-X&lt;/doi&gt;\n              &lt;/addata&gt;\n
-        \           &lt;/record&gt;\n          &lt;/PrimoNMBib&gt;\n          &lt;sear:GETIT
-        GetIt2=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&quot;
-        GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&quot;
-        deliveryCategory=&quot;Remote Search Resource&quot;/&gt;\n          &lt;sear:LINKS&gt;\n
-        \           &lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=X-rays%20show%20why%20van%20Gogh%27s%20yellows%20have%20darkened&amp;rft.jtitle=New%20Scientist&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=209&amp;rft.issue=2800&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=5&amp;rft.epage=5&amp;rft.pages=5-5&amp;rft.artnum=&amp;rft.issn=0262-4079&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/S0262-4079(11)60359-X&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier&gt;S0262-4079(11)60359-X&lt;/sciversesciencedirect_elsevier&gt;&amp;rft_id=info:oai/]]&gt;&lt;/sear:openurl&gt;\n
-        \           &lt;sear:backlink&gt;http://dx.doi.org/10.1016/S0262-4079(11)60359-X&lt;/sear:backlink&gt;\n
-        \           &lt;sear:thumbnail/&gt;\n            &lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=X-rays%20show%20why%20van%20Gogh%27s%20yellows%20have%20darkened&amp;rft.jtitle=New%20Scientist&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=209&amp;rft.issue=2800&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=5&amp;rft.epage=5&amp;rft.pages=5-5&amp;rft.artnum=&amp;rft.issn=0262-4079&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/S0262-4079(11)60359-X&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier&gt;S0262-4079(11)60359-X&lt;/sciversesciencedirect_elsevier&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article]]&gt;&lt;/sear:openurlfulltext&gt;\n
-        \         &lt;/sear:LINKS&gt;\n        &lt;/sear:DOC&gt;\n        &lt;sear:DOC
-        LOCAL=&quot;false&quot; SEARCH_ENGINE_TYPE=&quot;Primo Central Search Engine&quot;
-        SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; NO=&quot;3&quot; RANK=&quot;0.2361394&quot;
-        ID=&quot;233740531&quot;&gt;\n          &lt;PrimoNMBib xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;\n
-        \           &lt;record&gt;\n              &lt;control&gt;\n                &lt;sourcerecordid&gt;10.2307/25579974&lt;/sourcerecordid&gt;\n
-        \               &lt;sourceid&gt;jstor&lt;/sourceid&gt;\n                &lt;recordid&gt;TN_jstor10.2307/25579974&lt;/recordid&gt;\n
+        \               &lt;booster2&gt;1&lt;/booster2&gt;\n                &lt;pcg_type&gt;aggregator_crossref&lt;/pcg_type&gt;\n
+        \             &lt;/ranking&gt;\n              &lt;addata&gt;\n                &lt;atitle&gt;Van
+        Gogh&lt;/atitle&gt;\n                &lt;jtitle&gt;Choice Reviews Online&lt;/jtitle&gt;\n
+        \               &lt;date&gt;19981201&lt;/date&gt;\n                &lt;risdate&gt;19981201&lt;/risdate&gt;\n
+        \               &lt;volume&gt;36&lt;/volume&gt;\n                &lt;issue&gt;04&lt;/issue&gt;\n
+        \               &lt;spage&gt;36-1963&lt;/spage&gt;\n                &lt;epage&gt;36-1963&lt;/epage&gt;\n
+        \               &lt;pages&gt;36-1963-36-1963&lt;/pages&gt;\n                &lt;issn&gt;0009-4978&lt;/issn&gt;\n
+        \               &lt;eissn&gt;1523-8253&lt;/eissn&gt;\n                &lt;genre&gt;article&lt;/genre&gt;\n
+        \               &lt;ristype&gt;JOUR&lt;/ristype&gt;\n                &lt;doi&gt;10.5860/CHOICE.36-1963&lt;/doi&gt;\n
+        \             &lt;/addata&gt;\n            &lt;/record&gt;\n          &lt;/PrimoNMBib&gt;\n
+        \       &lt;sear:GETIT deliveryCategory=&quot;Remote Search Resource&quot;
+        GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-crossref&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Van%20Gogh&amp;amp;rft.jtitle=Choice%20Reviews%20Online&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=19981201&amp;amp;rft.volume=36&amp;amp;rft.issue=04&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=36-1963&amp;amp;rft.epage=36-1963&amp;amp;rft.pages=36-1963-36-1963&amp;amp;rft.artnum=&amp;amp;rft.issn=0009-4978&amp;amp;rft.eissn=1523-8253&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.5860/CHOICE.36-1963&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;crossref&gt;10.5860/CHOICE.36-1963&amp;lt;/crossref&gt;&amp;lt;grp_id&gt;5418720077066216478&amp;lt;/grp_id&gt;&amp;lt;oa&gt;&amp;lt;/oa&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&amp;amp;req.language=&quot;
+        GetIt2=&quot;&quot;/&gt;&lt;sear:LINKS&gt;&lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-crossref&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh&amp;rft.jtitle=Choice%20Reviews%20Online&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=19981201&amp;rft.volume=36&amp;rft.issue=04&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=36-1963&amp;rft.epage=36-1963&amp;rft.pages=36-1963-36-1963&amp;rft.artnum=&amp;rft.issn=0009-4978&amp;rft.eissn=1523-8253&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.5860/CHOICE.36-1963&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;crossref&gt;10.5860/CHOICE.36-1963&lt;/crossref&gt;&lt;grp_id&gt;5418720077066216478&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;req.language=]]&gt;&lt;/sear:openurl&gt;&lt;sear:thumbnail/&gt;&lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-crossref&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh&amp;rft.jtitle=Choice%20Reviews%20Online&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=19981201&amp;rft.volume=36&amp;rft.issue=04&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=36-1963&amp;rft.epage=36-1963&amp;rft.pages=36-1963-36-1963&amp;rft.artnum=&amp;rft.issn=0009-4978&amp;rft.eissn=1523-8253&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.5860/CHOICE.36-1963&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;crossref&gt;10.5860/CHOICE.36-1963&lt;/crossref&gt;&lt;grp_id&gt;5418720077066216478&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article&amp;req.language=]]&gt;&lt;/sear:openurlfulltext&gt;&lt;sear:addlink&gt;https://exlibris-pub.s3.amazonaws.com/aboutCrossref.html&lt;/sear:addlink&gt;&lt;/sear:LINKS&gt;&lt;/sear:DOC&gt;\n
+        \       &lt;sear:DOC ID=&quot;56137930&quot; RANK=&quot;0.1&quot; NO=&quot;2&quot;
+        SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; SEARCH_ENGINE_TYPE=&quot;Primo
+        Central Search Engine&quot; LOCAL=&quot;false&quot;&gt;\n          &lt;PrimoNMBib
+        xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;\n
+        \           &lt;record&gt;\n              &lt;control&gt;\n                &lt;sourcerecordid&gt;275312207&lt;/sourcerecordid&gt;\n
+        \               &lt;sourceid&gt;gale_ofa&lt;/sourceid&gt;\n                &lt;recordid&gt;TN_gale_ofa275312207&lt;/recordid&gt;\n
+        \               &lt;sourceformat&gt;XML&lt;/sourceformat&gt;\n                &lt;sourcesystem&gt;Other&lt;/sourcesystem&gt;\n
+        \             &lt;/control&gt;\n              &lt;display&gt;\n                &lt;type&gt;article&lt;/type&gt;\n
+        \               &lt;title&gt;Van Gogh: The Life&lt;/title&gt;\n                &lt;creator&gt;Bethune,
+        Brian&lt;/creator&gt;\n                &lt;ispartof&gt;Maclean's, Dec 5, 2011,
+        Vol.124(47), p.77(1)&lt;/ispartof&gt;\n                &lt;identifier&gt;&amp;lt;b&gt;ISSN:
+        &amp;lt;/b&gt;0024-9262&lt;/identifier&gt;\n                &lt;language&gt;English&lt;/language&gt;\n
+        \               &lt;source&gt;Cengage Learning, Inc.&lt;/source&gt;\n              &lt;/display&gt;\n
+        \             &lt;links&gt;\n                &lt;openurl&gt;$$Topenurl_article&lt;/openurl&gt;\n
+        \               &lt;openurlfulltext&gt;$$Topenurlfull_article&lt;/openurlfulltext&gt;\n
+        \             &lt;/links&gt;\n              &lt;search&gt;\n                &lt;scope&gt;gale_onefileg&lt;/scope&gt;\n
+        \               &lt;scope&gt;gale_onefilea&lt;/scope&gt;\n                &lt;creatorcontrib&gt;Bethune,
+        Brian&lt;/creatorcontrib&gt;\n                &lt;creatorcontrib&gt;Bethune&lt;/creatorcontrib&gt;\n
+        \               &lt;title&gt;Van Gogh: The Life.&lt;/title&gt;\n                &lt;general&gt;English&lt;/general&gt;\n
+        \               &lt;general&gt;Rogers Publishing Ltd.&lt;/general&gt;\n                &lt;general&gt;Cengage
+        Learning, Inc.&lt;/general&gt;\n                &lt;sourceid&gt;gale_ofa&lt;/sourceid&gt;\n
+        \               &lt;recordid&gt;gale_ofa275312207&lt;/recordid&gt;\n                &lt;issn&gt;0024-9262&lt;/issn&gt;\n
+        \               &lt;issn&gt;00249262&lt;/issn&gt;\n                &lt;rsrctype&gt;article&lt;/rsrctype&gt;\n
+        \               &lt;creationdate&gt;2011&lt;/creationdate&gt;\n                &lt;recordtype&gt;article&lt;/recordtype&gt;\n
+        \               &lt;addtitle&gt;Maclean's&lt;/addtitle&gt;\n                &lt;searchscope&gt;OneFile&lt;/searchscope&gt;\n
+        \               &lt;scope&gt;OneFile&lt;/scope&gt;\n              &lt;/search&gt;\n
+        \             &lt;sort&gt;\n                &lt;title&gt;Van Gogh: The Life.&lt;/title&gt;\n
+        \               &lt;author&gt;Bethune, Brian&lt;/author&gt;\n                &lt;creationdate&gt;20111205&lt;/creationdate&gt;\n
+        \             &lt;/sort&gt;\n              &lt;facets&gt;\n                &lt;frbrgroupid&gt;4412197537331139454&lt;/frbrgroupid&gt;\n
+        \               &lt;frbrtype&gt;6&lt;/frbrtype&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
+        \               &lt;creationdate&gt;2011&lt;/creationdate&gt;\n                &lt;collection&gt;OneFile
+        (GALE)&lt;/collection&gt;\n                &lt;prefilter&gt;articles&lt;/prefilter&gt;\n
+        \               &lt;rsrctype&gt;articles&lt;/rsrctype&gt;\n                &lt;creatorcontrib&gt;Bethune,
+        Brian&lt;/creatorcontrib&gt;\n                &lt;jtitle&gt;Maclean's&lt;/jtitle&gt;\n
+        \             &lt;/facets&gt;\n              &lt;frbr&gt;\n                &lt;t&gt;2&lt;/t&gt;\n
+        \               &lt;k1&gt;2011&lt;/k1&gt;\n                &lt;k2&gt;00249262&lt;/k2&gt;\n
+        \               &lt;k4&gt;124&lt;/k4&gt;\n                &lt;k5&gt;47&lt;/k5&gt;\n
+        \               &lt;k6&gt;77&lt;/k6&gt;\n                &lt;k7&gt;maclean
+        apos s&lt;/k7&gt;\n                &lt;k8&gt;van gogh the life&lt;/k8&gt;\n
+        \               &lt;k9&gt;vangoghthelife&lt;/k9&gt;\n                &lt;k15&gt;brianbethune&lt;/k15&gt;\n
+        \               &lt;k16&gt;bethunebrian&lt;/k16&gt;\n              &lt;/frbr&gt;\n
+        \             &lt;delivery&gt;\n                &lt;delcategory&gt;Remote
+        Search Resource&lt;/delcategory&gt;\n                &lt;fulltext&gt;fulltext&lt;/fulltext&gt;\n
+        \             &lt;/delivery&gt;\n              &lt;ranking&gt;\n                &lt;booster1&gt;1&lt;/booster1&gt;\n
+        \               &lt;booster2&gt;1&lt;/booster2&gt;\n                &lt;pcg_type&gt;aggregator&lt;/pcg_type&gt;\n
+        \             &lt;/ranking&gt;\n              &lt;addata&gt;\n                &lt;au&gt;Bethune,
+        Brian&lt;/au&gt;\n                &lt;atitle&gt;Van Gogh: The Life.&lt;/atitle&gt;\n
+        \               &lt;jtitle&gt;Maclean's&lt;/jtitle&gt;\n                &lt;date&gt;20111205&lt;/date&gt;\n
+        \               &lt;risdate&gt;20111205&lt;/risdate&gt;\n                &lt;volume&gt;124&lt;/volume&gt;\n
+        \               &lt;issue&gt;47&lt;/issue&gt;\n                &lt;spage&gt;77&lt;/spage&gt;\n
+        \               &lt;issn&gt;0024-9262&lt;/issn&gt;\n                &lt;genre&gt;article&lt;/genre&gt;\n
+        \               &lt;ristype&gt;JOUR&lt;/ristype&gt;\n                &lt;pub&gt;Rogers
+        Publishing Ltd.&lt;/pub&gt;\n                &lt;lad01&gt;gale_ofa&lt;/lad01&gt;\n
+        \             &lt;/addata&gt;\n            &lt;/record&gt;\n          &lt;/PrimoNMBib&gt;\n
+        \       &lt;sear:GETIT deliveryCategory=&quot;Remote Search Resource&quot;
+        GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Van%20Gogh:%20The%20Life.&amp;amp;rft.jtitle=Maclean%27s&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=Bethune%2C%20Brian&amp;amp;rft.aucorp=&amp;amp;rft.date=20111205&amp;amp;rft.volume=124&amp;amp;rft.issue=47&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=77&amp;amp;rft.epage=&amp;amp;rft.pages=&amp;amp;rft.artnum=&amp;amp;rft.issn=0024-9262&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;gale_ofa&gt;275312207&amp;lt;/gale_ofa&gt;&amp;lt;grp_id&gt;4412197537331139454&amp;lt;/grp_id&gt;&amp;lt;oa&gt;&amp;lt;/oa&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&amp;amp;req.language=&quot;
+        GetIt2=&quot;&quot;/&gt;&lt;sear:LINKS&gt;&lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh:%20The%20Life.&amp;rft.jtitle=Maclean%27s&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Bethune%2C%20Brian&amp;rft.aucorp=&amp;rft.date=20111205&amp;rft.volume=124&amp;rft.issue=47&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=77&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0024-9262&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;gale_ofa&gt;275312207&lt;/gale_ofa&gt;&lt;grp_id&gt;4412197537331139454&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;req.language=]]&gt;&lt;/sear:openurl&gt;&lt;sear:thumbnail/&gt;&lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh:%20The%20Life.&amp;rft.jtitle=Maclean%27s&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Bethune%2C%20Brian&amp;rft.aucorp=&amp;rft.date=20111205&amp;rft.volume=124&amp;rft.issue=47&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=77&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0024-9262&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;gale_ofa&gt;275312207&lt;/gale_ofa&gt;&lt;grp_id&gt;4412197537331139454&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article&amp;req.language=]]&gt;&lt;/sear:openurlfulltext&gt;&lt;/sear:LINKS&gt;&lt;/sear:DOC&gt;\n
+        \       &lt;sear:DOC ID=&quot;593203908&quot; RANK=&quot;0.1&quot; NO=&quot;3&quot;
+        SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; SEARCH_ENGINE_TYPE=&quot;Primo
+        Central Search Engine&quot; LOCAL=&quot;false&quot;&gt;\n          &lt;PrimoNMBib
+        xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;\n
+        \           &lt;record&gt;\n              &lt;control&gt;\n                &lt;sourcerecordid&gt;25579974&lt;/sourcerecordid&gt;\n
+        \               &lt;sourceid&gt;jstor_archive&lt;/sourceid&gt;\n                &lt;recordid&gt;TN_jstor_archive25579974&lt;/recordid&gt;\n
         \               &lt;sourceformat&gt;XML&lt;/sourceformat&gt;\n                &lt;sourcesystem&gt;Other&lt;/sourcesystem&gt;\n
         \             &lt;/control&gt;\n              &lt;display&gt;\n                &lt;type&gt;article&lt;/type&gt;\n
         \               &lt;title&gt;Van Gogh&lt;/title&gt;\n                &lt;creator&gt;Smyth,
         Gerard&lt;/creator&gt;\n                &lt;ispartof&gt;The Poetry Ireland
-        Review, 2002(72), pp.85&lt;/ispartof&gt;\n                &lt;identifier&gt;&amp;lt;b&gt;ISSN:&amp;lt;/b&gt;
-        03322998&lt;/identifier&gt;\n                &lt;subject&gt;Literature&lt;/subject&gt;\n
-        \               &lt;language&gt;eng&lt;/language&gt;\n                &lt;source&gt;JSTOR&lt;/source&gt;\n
-        \             &lt;/display&gt;\n              &lt;links&gt;\n                &lt;openurl&gt;$$Topenurl_article&lt;/openurl&gt;\n
-        \               &lt;backlink&gt;$$Uhttp://www.jstor.org/stable/10.2307/25579974?origin=api$$EView_this_record_in_JSTOR&lt;/backlink&gt;\n
+        Review, 2002(72), pp.85-85&lt;/ispartof&gt;\n                &lt;identifier&gt;&amp;lt;b&gt;ISSN:&amp;lt;/b&gt;
+        03322998&lt;/identifier&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
+        \               &lt;source&gt;JSTOR&lt;/source&gt;\n              &lt;/display&gt;\n
+        \             &lt;links&gt;\n                &lt;openurl&gt;$$Topenurl_article&lt;/openurl&gt;\n
+        \               &lt;backlink&gt;$$Uhttp://www.jstor.org/stable/25579974$$EView_this_record_in_JSTOR&lt;/backlink&gt;\n
         \               &lt;openurlfulltext&gt;$$Topenurlfull_article&lt;/openurlfulltext&gt;\n
         \             &lt;/links&gt;\n              &lt;search&gt;\n                &lt;creatorcontrib&gt;Smyth,
         Gerard&lt;/creatorcontrib&gt;\n                &lt;title&gt;Van Gogh&lt;/title&gt;\n
-        \               &lt;subject&gt;literature&lt;/subject&gt;\n                &lt;general&gt;10.2307/25579974&lt;/general&gt;\n
         \               &lt;general&gt;English&lt;/general&gt;\n                &lt;general&gt;JSOTR&lt;/general&gt;\n
-        \               &lt;sourceid&gt;jstor&lt;/sourceid&gt;\n                &lt;recordid&gt;jstor10.2307/25579974&lt;/recordid&gt;\n
-        \               &lt;issn&gt;0332-2998&lt;/issn&gt;\n                &lt;issn&gt;03322998&lt;/issn&gt;\n
-        \               &lt;rsrctype&gt;article&lt;/rsrctype&gt;\n                &lt;creationdate&gt;2002&lt;/creationdate&gt;\n
-        \               &lt;recordtype&gt;article&lt;/recordtype&gt;\n                &lt;addtitle&gt;The
-        Poetry Ireland Review&lt;/addtitle&gt;\n                &lt;searchscope&gt;jstor&lt;/searchscope&gt;\n
-        \               &lt;searchscope&gt;jstor_ic&lt;/searchscope&gt;\n                &lt;scope&gt;jstor&lt;/scope&gt;\n
-        \               &lt;scope&gt;jstor_ic&lt;/scope&gt;\n              &lt;/search&gt;\n
-        \             &lt;sort&gt;\n                &lt;title&gt;Van Gogh&lt;/title&gt;\n
-        \               &lt;author&gt;Smyth, Gerard&lt;/author&gt;\n                &lt;creationdate&gt;20020401&lt;/creationdate&gt;\n
-        \             &lt;/sort&gt;\n              &lt;facets&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
-        \               &lt;creationdate&gt;2002&lt;/creationdate&gt;\n                &lt;topic&gt;Literature&lt;/topic&gt;\n
-        \               &lt;collection&gt;Ireland (JSTOR)&lt;/collection&gt;\n                &lt;prefilter&gt;articles&lt;/prefilter&gt;\n
-        \               &lt;rsrctype&gt;articles&lt;/rsrctype&gt;\n                &lt;creatorcontrib&gt;Smyth,
-        Gerard&lt;/creatorcontrib&gt;\n                &lt;jtitle&gt;Poetry Ireland
-        Review&lt;/jtitle&gt;\n                &lt;frbrgroupid&gt;593784593&lt;/frbrgroupid&gt;\n
-        \               &lt;frbrtype&gt;6&lt;/frbrtype&gt;\n              &lt;/facets&gt;\n
+        \               &lt;general&gt;Poetry Ireland Ltd.&lt;/general&gt;\n                &lt;sourceid&gt;jstor_archive&lt;/sourceid&gt;\n
+        \               &lt;recordid&gt;jstor_archive25579974&lt;/recordid&gt;\n                &lt;issn&gt;0332-2998&lt;/issn&gt;\n
+        \               &lt;issn&gt;03322998&lt;/issn&gt;\n                &lt;rsrctype&gt;article&lt;/rsrctype&gt;\n
+        \               &lt;creationdate&gt;2002&lt;/creationdate&gt;\n                &lt;recordtype&gt;article&lt;/recordtype&gt;\n
+        \               &lt;addtitle&gt;The Poetry Ireland Review&lt;/addtitle&gt;\n
+        \               &lt;searchscope&gt;jstor_ic&lt;/searchscope&gt;\n                &lt;scope&gt;jstor_ic&lt;/scope&gt;\n
+        \             &lt;/search&gt;\n              &lt;sort&gt;\n                &lt;title&gt;Van
+        Gogh&lt;/title&gt;\n                &lt;author&gt;Smyth, Gerard&lt;/author&gt;\n
+        \               &lt;creationdate&gt;20020401&lt;/creationdate&gt;\n              &lt;/sort&gt;\n
+        \             &lt;facets&gt;\n                &lt;frbrgroupid&gt;2843262240286033619&lt;/frbrgroupid&gt;\n
+        \               &lt;frbrtype&gt;6&lt;/frbrtype&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
+        \               &lt;creationdate&gt;2002&lt;/creationdate&gt;\n                &lt;collection&gt;JSTOR&lt;/collection&gt;\n
+        \               &lt;prefilter&gt;articles&lt;/prefilter&gt;\n                &lt;rsrctype&gt;articles&lt;/rsrctype&gt;\n
+        \               &lt;creatorcontrib&gt;Smyth, Gerard&lt;/creatorcontrib&gt;\n
+        \               &lt;jtitle&gt;Poetry Ireland Review&lt;/jtitle&gt;\n              &lt;/facets&gt;\n
         \             &lt;frbr&gt;\n                &lt;t&gt;2&lt;/t&gt;\n                &lt;k1&gt;2002&lt;/k1&gt;\n
         \               &lt;k2&gt;03322998&lt;/k2&gt;\n                &lt;k5&gt;72&lt;/k5&gt;\n
         \               &lt;k6&gt;85&lt;/k6&gt;\n                &lt;k7&gt;poetry
@@ -448,214 +433,182 @@ http_interactions:
         \             &lt;/ranking&gt;\n              &lt;addata&gt;\n                &lt;aulast&gt;Smyth&lt;/aulast&gt;\n
         \               &lt;aufirst&gt;Gerard&lt;/aufirst&gt;\n                &lt;au&gt;Smyth,
         Gerard&lt;/au&gt;\n                &lt;atitle&gt;Van Gogh&lt;/atitle&gt;\n
-        \               &lt;jtitle&gt;The Poetry Ireland Review&lt;/jtitle&gt;\n                &lt;issue&gt;72&lt;/issue&gt;\n
+        \               &lt;jtitle&gt;The Poetry Ireland Review&lt;/jtitle&gt;\n                &lt;date&gt;20020401&lt;/date&gt;\n
+        \               &lt;risdate&gt;20020401&lt;/risdate&gt;\n                &lt;issue&gt;72&lt;/issue&gt;\n
         \               &lt;spage&gt;85&lt;/spage&gt;\n                &lt;epage&gt;85&lt;/epage&gt;\n
         \               &lt;pages&gt;85-85&lt;/pages&gt;\n                &lt;issn&gt;03322998&lt;/issn&gt;\n
-        \               &lt;genre&gt;article&lt;/genre&gt;\n                &lt;ristype&gt;JOUR&lt;/ristype&gt;\n
-        \               &lt;pub&gt;Poetry Ireland&lt;/pub&gt;\n                &lt;url&gt;http://www.jstor.org/stable/10.2307/25579974?origin=api&lt;/url&gt;\n
-        \               &lt;lad02&gt;20020401&lt;/lad02&gt;\n                &lt;date&gt;20020401&lt;/date&gt;\n
-        \               &lt;risdate&gt;20020401&lt;/risdate&gt;\n              &lt;/addata&gt;\n
-        \           &lt;/record&gt;\n          &lt;/PrimoNMBib&gt;\n          &lt;sear:GETIT
-        GetIt2=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&quot;
-        GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&quot;
-        deliveryCategory=&quot;Remote Search Resource&quot;/&gt;\n          &lt;sear:LINKS&gt;\n
-        \           &lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-jstor&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh&amp;rft.jtitle=The%20Poetry%20Ireland%20Review&amp;rft.btitle=&amp;rft.aulast=Smyth&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Smyth%2C%20Gerard&amp;rft.aucorp=&amp;rft.date=20020401&amp;rft.volume=&amp;rft.issue=72&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=85&amp;rft.epage=85&amp;rft.pages=85-85&amp;rft.artnum=&amp;rft.issn=03322998&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;jstor&gt;10.2307/25579974&lt;/jstor&gt;&amp;rft_id=info:oai/]]&gt;&lt;/sear:openurl&gt;\n
-        \           &lt;sear:backlink&gt;http://www.jstor.org/stable/10.2307/25579974?origin=api&lt;/sear:backlink&gt;\n
-        \           &lt;sear:thumbnail/&gt;\n            &lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-jstor&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh&amp;rft.jtitle=The%20Poetry%20Ireland%20Review&amp;rft.btitle=&amp;rft.aulast=Smyth&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Smyth%2C%20Gerard&amp;rft.aucorp=&amp;rft.date=20020401&amp;rft.volume=&amp;rft.issue=72&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=85&amp;rft.epage=85&amp;rft.pages=85-85&amp;rft.artnum=&amp;rft.issn=03322998&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;jstor&gt;10.2307/25579974&lt;/jstor&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article]]&gt;&lt;/sear:openurlfulltext&gt;\n
-        \         &lt;/sear:LINKS&gt;\n        &lt;/sear:DOC&gt;\n        &lt;sear:DOC
-        LOCAL=&quot;false&quot; SEARCH_ENGINE_TYPE=&quot;Primo Central Search Engine&quot;
-        SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; NO=&quot;4&quot; RANK=&quot;0.1680907&quot;
-        ID=&quot;52122192&quot;&gt;\n          &lt;PrimoNMBib xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;\n
-        \           &lt;record&gt;\n              &lt;control&gt;\n                &lt;sourcerecordid&gt;10.1080/03017605.2011.561634&lt;/sourcerecordid&gt;\n
-        \               &lt;sourceid&gt;tayfranc&lt;/sourceid&gt;\n                &lt;recordid&gt;TN_tayfranc10.1080/03017605.2011.561634&lt;/recordid&gt;\n
+        \               &lt;format&gt;journal&lt;/format&gt;\n                &lt;genre&gt;article&lt;/genre&gt;\n
+        \               &lt;ristype&gt;JOUR&lt;/ristype&gt;\n                &lt;pub&gt;Poetry
+        Ireland Ltd.&lt;/pub&gt;\n              &lt;/addata&gt;\n            &lt;/record&gt;\n
+        \         &lt;/PrimoNMBib&gt;\n        &lt;sear:GETIT deliveryCategory=&quot;Remote
+        Search Resource&quot; GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-jstor_archive&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:journal&amp;amp;rft.genre=article&amp;amp;rft.atitle=Van%20Gogh&amp;amp;rft.jtitle=The%20Poetry%20Ireland%20Review&amp;amp;rft.btitle=&amp;amp;rft.aulast=Smyth&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=Smyth%2C%20Gerard&amp;amp;rft.aucorp=&amp;amp;rft.date=20020401&amp;amp;rft.volume=&amp;amp;rft.issue=72&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=85&amp;amp;rft.epage=85&amp;amp;rft.pages=85-85&amp;amp;rft.artnum=&amp;amp;rft.issn=03322998&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;jstor_archive&gt;25579974&amp;lt;/jstor_archive&gt;&amp;lt;grp_id&gt;2843262240286033619&amp;lt;/grp_id&gt;&amp;lt;oa&gt;&amp;lt;/oa&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&amp;amp;req.language=&quot;
+        GetIt2=&quot;&quot;/&gt;&lt;sear:LINKS&gt;&lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-jstor_archive&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:journal&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh&amp;rft.jtitle=The%20Poetry%20Ireland%20Review&amp;rft.btitle=&amp;rft.aulast=Smyth&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Smyth%2C%20Gerard&amp;rft.aucorp=&amp;rft.date=20020401&amp;rft.volume=&amp;rft.issue=72&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=85&amp;rft.epage=85&amp;rft.pages=85-85&amp;rft.artnum=&amp;rft.issn=03322998&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;jstor_archive&gt;25579974&lt;/jstor_archive&gt;&lt;grp_id&gt;2843262240286033619&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;req.language=]]&gt;&lt;/sear:openurl&gt;&lt;sear:backlink&gt;http://www.jstor.org/stable/25579974&lt;/sear:backlink&gt;&lt;sear:thumbnail/&gt;&lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-jstor_archive&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:journal&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh&amp;rft.jtitle=The%20Poetry%20Ireland%20Review&amp;rft.btitle=&amp;rft.aulast=Smyth&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Smyth%2C%20Gerard&amp;rft.aucorp=&amp;rft.date=20020401&amp;rft.volume=&amp;rft.issue=72&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=85&amp;rft.epage=85&amp;rft.pages=85-85&amp;rft.artnum=&amp;rft.issn=03322998&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;jstor_archive&gt;25579974&lt;/jstor_archive&gt;&lt;grp_id&gt;2843262240286033619&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article&amp;req.language=]]&gt;&lt;/sear:openurlfulltext&gt;&lt;/sear:LINKS&gt;&lt;/sear:DOC&gt;\n
+        \       &lt;sear:DOC ID=&quot;88661624&quot; RANK=&quot;0.050083812&quot;
+        NO=&quot;4&quot; SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; SEARCH_ENGINE_TYPE=&quot;Primo
+        Central Search Engine&quot; LOCAL=&quot;false&quot;&gt;\n          &lt;PrimoNMBib
+        xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;\n
+        \           &lt;record&gt;\n              &lt;control&gt;\n                &lt;sourcerecordid&gt;147615120&lt;/sourcerecordid&gt;\n
+        \               &lt;sourceid&gt;gale_ofa&lt;/sourceid&gt;\n                &lt;recordid&gt;TN_gale_ofa147615120&lt;/recordid&gt;\n
         \               &lt;sourceformat&gt;XML&lt;/sourceformat&gt;\n                &lt;sourcesystem&gt;Other&lt;/sourcesystem&gt;\n
         \             &lt;/control&gt;\n              &lt;display&gt;\n                &lt;type&gt;article&lt;/type&gt;\n
-        \               &lt;title&gt;Vincent van Gogh&lt;/title&gt;\n                &lt;creator&gt;Mckenna,
-        Tony&lt;/creator&gt;\n                &lt;publisher&gt;Taylor &amp;amp; Francis
-        Group&lt;/publisher&gt;\n                &lt;ispartof&gt;Critique, 2011, Vol.39(2),
-        p.295-303&lt;/ispartof&gt;\n                &lt;identifier&gt;&lt;![CDATA[&lt;b&gt;ISSN:
-        &lt;/b&gt;0301-7605 ; &lt;b&gt;E-ISSN: &lt;/b&gt;1748-8605 ; &lt;b&gt;DOI:
-        &lt;/b&gt;10.1080/03017605.2011.561634]]&gt;&lt;/identifier&gt;\n                &lt;subject&gt;Van
-        Gogh ; Alienation ; Religion ; Art&lt;/subject&gt;\n                &lt;description&gt;Van
-        Gogh's story is beautifully sad. It was only in the last ten years of his
-        life that he took up painting. During that time he produced works of such
-        vehement intensity that their reproductions are to be found across the globe;
-        those signature images of sunflowers and blazing stars which have since passed
-        into permanence, resonating the thoughts and feelings of each successive generation.
-        Yet in his own lifetime Vincent experienced dismal failure and was unable
-        to sell a single work. He was no more successful in his personal life; the
-        few friends he did manage to make were quickly lost, and he was never able
-        to start a family. Vincent's life faltered between hope and despair; each
-        new connection he tried to forge was brutally disappointed. It is the writer's
-        contention that the art of Van Gogh can be better understood by referencing
-        the historical context of his life. That the loneliness Vincent experienced
-        was at the same time the pre-condition for the beauty, melancholy and power
-        of the art he produced. It was the relentless and alienating objectivities
-        of the world he encountered which forced him to turn inward, to develop a
-        rich mental life which was to culminate in both genius and madness. Vincent
-        committed suicide at the age of 37.&lt;/description&gt;\n                &lt;source&gt;Routledge,
-        Taylor &amp;amp; Francis Group&amp;lt;img src=&quot;https://exlibris-pub.s3.amazonaws.com/Routledge_RGB.jpg&quot;
-        style=&quot;vertical-align:middle;margin-left:7px&quot;&gt;&lt;/source&gt;\n
-        \               &lt;lds50&gt;peer_reviewed&lt;/lds50&gt;\n                &lt;version&gt;1&lt;/version&gt;\n
-        \             &lt;/display&gt;\n              &lt;links&gt;\n                &lt;openurl&gt;$$Topenurl_article&lt;/openurl&gt;\n
-        \               &lt;openurlfulltext&gt;$$Topenurlfull_article&lt;/openurlfulltext&gt;\n
-        \               &lt;addlink&gt;$$Uhttps://exlibris-pub.s3.amazonaws.com/aboutTaylorFrancis.html$$EView_Taylor_&amp;amp;_Francis_Group_Copyright_Statement&lt;/addlink&gt;\n
-        \             &lt;/links&gt;\n              &lt;search&gt;\n                &lt;creatorcontrib&gt;McKenna,
-        Tony&lt;/creatorcontrib&gt;\n                &lt;title&gt;Vincent van Gogh&lt;/title&gt;\n
-        \               &lt;description&gt;Van Gogh's story is beautifully sad. It
-        was only in the last ten years of his life that he took up painting. During
-        that time he produced works of such vehement intensity that their reproductions
-        are to be found across the globe; those signature images of sunflowers and
-        blazing stars which have since passed into permanence, resonating the thoughts
-        and feelings of each successive generation. Yet in his own lifetime Vincent
-        experienced dismal failure and was unable to sell a single work. He was no
-        more successful in his personal life; the few friends he did manage to make
-        were quickly lost, and he was never able to start a family. Vincent's life
-        faltered between hope and despair; each new connection he tried to forge was
-        brutally disappointed. It is the writer's contention that the art of Van Gogh
-        can be better understood by referencing the historical context of his life.
-        That the loneliness Vincent experienced was at the same time the pre-condition
-        for the beauty, melancholy and power of the art he produced. It was the relentless
-        and alienating objectivities of the world he encountered which forced him
-        to turn inward, to develop a rich mental life which was to culminate in both
-        genius and madness. Vincent committed suicide at the age of 37.&lt;/description&gt;\n
-        \               &lt;subject&gt;Van Gogh&lt;/subject&gt;\n                &lt;subject&gt;Alienation&lt;/subject&gt;\n
-        \               &lt;subject&gt;Religion&lt;/subject&gt;\n                &lt;subject&gt;Art&lt;/subject&gt;\n
-        \               &lt;general&gt;10.1080/03017605.2011.561634&lt;/general&gt;\n
-        \               &lt;general&gt;Critique, Vol. 39, No. 2, May 2011, pp. 295&#x2013;303&lt;/general&gt;\n
-        \               &lt;general&gt;Taylor &amp;amp; Francis Group&lt;/general&gt;\n
-        \               &lt;sourceid&gt;tayfranc&lt;/sourceid&gt;\n                &lt;recordid&gt;tayfranc10.1080/03017605.2011.561634&lt;/recordid&gt;\n
-        \               &lt;issn&gt;0301-7605&lt;/issn&gt;\n                &lt;issn&gt;03017605&lt;/issn&gt;\n
-        \               &lt;issn&gt;1748-8605&lt;/issn&gt;\n                &lt;issn&gt;17488605&lt;/issn&gt;\n
-        \               &lt;rsrctype&gt;article&lt;/rsrctype&gt;\n                &lt;creationdate&gt;2011&lt;/creationdate&gt;\n
-        \               &lt;addtitle&gt;Critique: Journal of Socialist Theory&lt;/addtitle&gt;\n
-        \               &lt;searchscope&gt;tayfranc&lt;/searchscope&gt;\n                &lt;searchscope&gt;taylor_francis&lt;/searchscope&gt;\n
-        \               &lt;scope&gt;tayfranc&lt;/scope&gt;\n                &lt;scope&gt;taylor_francis&lt;/scope&gt;\n
-        \             &lt;/search&gt;\n              &lt;sort&gt;\n                &lt;title&gt;Vincent
-        van Gogh&lt;/title&gt;\n                &lt;author&gt;Mckenna, Tony&lt;/author&gt;\n
-        \               &lt;creationdate&gt;20110501&lt;/creationdate&gt;\n              &lt;/sort&gt;\n
-        \             &lt;facets&gt;\n                &lt;creationdate&gt;2011&lt;/creationdate&gt;\n
-        \               &lt;topic&gt;Van Gogh&lt;/topic&gt;\n                &lt;topic&gt;Alienation&lt;/topic&gt;\n
-        \               &lt;topic&gt;Religion&lt;/topic&gt;\n                &lt;topic&gt;Art&lt;/topic&gt;\n
-        \               &lt;collection&gt;Taylor &amp;amp; Francis Online - Journals&lt;/collection&gt;\n
-        \               &lt;prefilter&gt;articles&lt;/prefilter&gt;\n                &lt;rsrctype&gt;articles&lt;/rsrctype&gt;\n
-        \               &lt;creatorcontrib&gt;Mckenna, Tony&lt;/creatorcontrib&gt;\n
-        \               &lt;jtitle&gt;Critique&lt;/jtitle&gt;\n                &lt;toplevel&gt;peer_reviewed&lt;/toplevel&gt;\n
-        \               &lt;frbrgroupid&gt;8381996817650573379&lt;/frbrgroupid&gt;\n
-        \               &lt;frbrtype&gt;5&lt;/frbrtype&gt;\n              &lt;/facets&gt;\n
-        \             &lt;frbr&gt;\n                &lt;t&gt;2&lt;/t&gt;\n                &lt;k1&gt;2011&lt;/k1&gt;\n
-        \               &lt;k2&gt;03017605&lt;/k2&gt;\n                &lt;k2&gt;17488605&lt;/k2&gt;\n
-        \               &lt;k3&gt;10.1080/03017605.2011.561634&lt;/k3&gt;\n                &lt;k4&gt;39&lt;/k4&gt;\n
-        \               &lt;k5&gt;2&lt;/k5&gt;\n                &lt;k6&gt;295&lt;/k6&gt;\n
-        \               &lt;k7&gt;critique&lt;/k7&gt;\n                &lt;k8&gt;vincent
-        van gogh&lt;/k8&gt;\n                &lt;k9&gt;vincentvangogh&lt;/k9&gt;\n
-        \               &lt;k15&gt;tonymckenna&lt;/k15&gt;\n                &lt;k16&gt;mckennatony&lt;/k16&gt;\n
-        \             &lt;/frbr&gt;\n              &lt;delivery&gt;\n                &lt;delcategory&gt;Remote
-        Search Resource&lt;/delcategory&gt;\n                &lt;fulltext&gt;no_fulltext&lt;/fulltext&gt;\n
-        \             &lt;/delivery&gt;\n              &lt;ranking&gt;\n                &lt;booster1&gt;1&lt;/booster1&gt;\n
-        \               &lt;booster2&gt;1&lt;/booster2&gt;\n                &lt;pcg_type&gt;publisher&lt;/pcg_type&gt;\n
-        \             &lt;/ranking&gt;\n              &lt;addata&gt;\n                &lt;aulast&gt;McKenna&lt;/aulast&gt;\n
-        \               &lt;aufirst&gt;Tony&lt;/aufirst&gt;\n                &lt;au&gt;Mckenna,
-        Tony&lt;/au&gt;\n                &lt;atitle&gt;Vincent van Gogh&lt;/atitle&gt;\n
-        \               &lt;jtitle&gt;Critique&lt;/jtitle&gt;\n                &lt;addtitle&gt;Journal
-        of Socialist Theory&lt;/addtitle&gt;\n                &lt;date&gt;20110501&lt;/date&gt;\n
-        \               &lt;volume&gt;39&lt;/volume&gt;\n                &lt;issue&gt;2&lt;/issue&gt;\n
-        \               &lt;spage&gt;295&lt;/spage&gt;\n                &lt;epage&gt;303&lt;/epage&gt;\n
-        \               &lt;issn&gt;0301-7605&lt;/issn&gt;\n                &lt;eissn&gt;1748-8605&lt;/eissn&gt;\n
-        \               &lt;format&gt;article&lt;/format&gt;\n                &lt;genre&gt;article&lt;/genre&gt;\n
-        \               &lt;ristype&gt;JOUR&lt;/ristype&gt;\n                &lt;abstract&gt;Van
-        Gogh's story is beautifully sad. It was only in the last ten years of his
-        life that he took up painting. During that time he produced works of such
-        vehement intensity that their reproductions are to be found across the globe;
-        those signature images of sunflowers and blazing stars which have since passed
-        into permanence, resonating the thoughts and feelings of each successive generation.
-        Yet in his own lifetime Vincent experienced dismal failure and was unable
-        to sell a single work. He was no more successful in his personal life; the
-        few friends he did manage to make were quickly lost, and he was never able
-        to start a family. Vincent's life faltered between hope and despair; each
-        new connection he tried to forge was brutally disappointed. It is the writer's
-        contention that the art of Van Gogh can be better understood by referencing
-        the historical context of his life. That the loneliness Vincent experienced
-        was at the same time the pre-condition for the beauty, melancholy and power
-        of the art he produced. It was the relentless and alienating objectivities
-        of the world he encountered which forced him to turn inward, to develop a
-        rich mental life which was to culminate in both genius and madness. Vincent
-        committed suicide at the age of 37.&lt;/abstract&gt;\n                &lt;pub&gt;Taylor
-        &amp;amp; Francis Group&lt;/pub&gt;\n                &lt;doi&gt;10.1080/03017605.2011.561634&lt;/doi&gt;\n
-        \             &lt;/addata&gt;\n            &lt;/record&gt;\n          &lt;/PrimoNMBib&gt;\n
-        \         &lt;sear:GETIT GetIt2=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&quot;
-        GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&quot;
-        deliveryCategory=&quot;Remote Search Resource&quot;/&gt;\n          &lt;sear:LINKS&gt;\n
-        \           &lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-tayfranc&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:article&amp;rft.genre=article&amp;rft.atitle=Vincent%20van%20Gogh&amp;rft.jtitle=Critique&amp;rft.btitle=&amp;rft.aulast=McKenna&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Mckenna%2C%20Tony&amp;rft.aucorp=&amp;rft.date=20110501&amp;rft.volume=39&amp;rft.issue=2&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=295&amp;rft.epage=303&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0301-7605&amp;rft.eissn=1748-8605&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1080/03017605.2011.561634&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;tayfranc&gt;10.1080/03017605.2011.561634&lt;/tayfranc&gt;&amp;rft_id=info:oai/]]&gt;&lt;/sear:openurl&gt;\n
-        \           &lt;sear:thumbnail/&gt;\n            &lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-tayfranc&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:article&amp;rft.genre=article&amp;rft.atitle=Vincent%20van%20Gogh&amp;rft.jtitle=Critique&amp;rft.btitle=&amp;rft.aulast=McKenna&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Mckenna%2C%20Tony&amp;rft.aucorp=&amp;rft.date=20110501&amp;rft.volume=39&amp;rft.issue=2&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=295&amp;rft.epage=303&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0301-7605&amp;rft.eissn=1748-8605&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1080/03017605.2011.561634&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;tayfranc&gt;10.1080/03017605.2011.561634&lt;/tayfranc&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article]]&gt;&lt;/sear:openurlfulltext&gt;\n
-        \           &lt;sear:addlink&gt;https://exlibris-pub.s3.amazonaws.com/aboutTaylorFrancis.html&lt;/sear:addlink&gt;\n
-        \         &lt;/sear:LINKS&gt;\n        &lt;/sear:DOC&gt;\n        &lt;sear:DOC
-        LOCAL=&quot;false&quot; SEARCH_ENGINE_TYPE=&quot;Primo Central Search Engine&quot;
-        SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; NO=&quot;5&quot; RANK=&quot;0.15742625&quot;
-        ID=&quot;48605838&quot;&gt;\n          &lt;PrimoNMBib xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;\n
-        \           &lt;record&gt;\n              &lt;control&gt;\n                &lt;sourcerecordid&gt;10.2307/4611194&lt;/sourcerecordid&gt;\n
-        \               &lt;sourceid&gt;jstor&lt;/sourceid&gt;\n                &lt;recordid&gt;TN_jstor10.2307/4611194&lt;/recordid&gt;\n
-        \               &lt;sourceformat&gt;XML&lt;/sourceformat&gt;\n                &lt;sourcesystem&gt;Other&lt;/sourcesystem&gt;\n
-        \             &lt;/control&gt;\n              &lt;display&gt;\n                &lt;type&gt;article&lt;/type&gt;\n
-        \               &lt;title&gt;Van Gogh&lt;/title&gt;\n                &lt;creator&gt;Moore,
-        Barbara&lt;/creator&gt;\n                &lt;ispartof&gt;The Antioch Review,
-        1983, Vol.41(1), pp.73&lt;/ispartof&gt;\n                &lt;identifier&gt;&amp;lt;b&gt;ISSN:&amp;lt;/b&gt;
-        00035769&lt;/identifier&gt;\n                &lt;subject&gt;Literature&lt;/subject&gt;\n
-        \               &lt;language&gt;eng&lt;/language&gt;\n                &lt;source&gt;JSTOR&lt;/source&gt;\n
-        \               &lt;lds50&gt;peer_reviewed&lt;/lds50&gt;\n              &lt;/display&gt;\n
+        \               &lt;title&gt;What tortured the artist?(EDUCATION)(Vincent
+        van Gogh suffer of acute intermittent porphyria)(Brief article)&lt;/title&gt;\n
+        \               &lt;creator&gt;Leslie, Mitch&lt;/creator&gt;\n                &lt;ispartof&gt;Science,
+        April 28, 2006, Vol.312(5773), p.505(1)&lt;/ispartof&gt;\n                &lt;identifier&gt;&amp;lt;b&gt;ISSN:
+        &amp;lt;/b&gt;0036-8075&lt;/identifier&gt;\n                &lt;subject&gt;Porphyria
+        -- Research ; Porphyria -- Analysis&lt;/subject&gt;\n                &lt;language&gt;English&lt;/language&gt;\n
+        \               &lt;source&gt;Cengage Learning, Inc.&lt;/source&gt;\n                &lt;lds50&gt;peer_reviewed&lt;/lds50&gt;\n
+        \               &lt;version&gt;2&lt;/version&gt;\n              &lt;/display&gt;\n
         \             &lt;links&gt;\n                &lt;openurl&gt;$$Topenurl_article&lt;/openurl&gt;\n
-        \               &lt;backlink&gt;$$Uhttp://www.jstor.org/stable/10.2307/4611194?origin=api$$EView_this_record_in_JSTOR&lt;/backlink&gt;\n
         \               &lt;openurlfulltext&gt;$$Topenurlfull_article&lt;/openurlfulltext&gt;\n
-        \             &lt;/links&gt;\n              &lt;search&gt;\n                &lt;creatorcontrib&gt;Moore,
-        Barbara&lt;/creatorcontrib&gt;\n                &lt;title&gt;Van Gogh&lt;/title&gt;\n
-        \               &lt;subject&gt;literature&lt;/subject&gt;\n                &lt;general&gt;10.2307/4611194&lt;/general&gt;\n
-        \               &lt;general&gt;English&lt;/general&gt;\n                &lt;general&gt;JSOTR&lt;/general&gt;\n
-        \               &lt;sourceid&gt;jstor&lt;/sourceid&gt;\n                &lt;recordid&gt;jstor10.2307/4611194&lt;/recordid&gt;\n
-        \               &lt;issn&gt;0003-5769&lt;/issn&gt;\n                &lt;issn&gt;00035769&lt;/issn&gt;\n
-        \               &lt;rsrctype&gt;article&lt;/rsrctype&gt;\n                &lt;creationdate&gt;1983&lt;/creationdate&gt;\n
-        \               &lt;recordtype&gt;article&lt;/recordtype&gt;\n                &lt;addtitle&gt;The
-        Antioch Review&lt;/addtitle&gt;\n                &lt;searchscope&gt;jstor&lt;/searchscope&gt;\n
-        \               &lt;searchscope&gt;jstor_asc5&lt;/searchscope&gt;\n                &lt;scope&gt;jstor&lt;/scope&gt;\n
-        \               &lt;scope&gt;jstor_asc5&lt;/scope&gt;\n              &lt;/search&gt;\n
-        \             &lt;sort&gt;\n                &lt;title&gt;Van Gogh&lt;/title&gt;\n
-        \               &lt;author&gt;Moore, Barbara&lt;/author&gt;\n                &lt;creationdate&gt;19830101&lt;/creationdate&gt;\n
-        \             &lt;/sort&gt;\n              &lt;facets&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
-        \               &lt;creationdate&gt;1983&lt;/creationdate&gt;\n                &lt;topic&gt;Literature&lt;/topic&gt;\n
-        \               &lt;collection&gt;Arts &amp;amp; Sciences (JSTOR)&lt;/collection&gt;\n
-        \               &lt;prefilter&gt;articles&lt;/prefilter&gt;\n                &lt;rsrctype&gt;articles&lt;/rsrctype&gt;\n
-        \               &lt;creatorcontrib&gt;Moore, Barbara&lt;/creatorcontrib&gt;\n
-        \               &lt;jtitle&gt;Antioch Review&lt;/jtitle&gt;\n                &lt;toplevel&gt;peer_reviewed&lt;/toplevel&gt;\n
-        \               &lt;frbrgroupid&gt;591692547&lt;/frbrgroupid&gt;\n                &lt;frbrtype&gt;6&lt;/frbrtype&gt;\n
-        \             &lt;/facets&gt;\n              &lt;frbr&gt;\n                &lt;t&gt;2&lt;/t&gt;\n
-        \               &lt;k1&gt;1983&lt;/k1&gt;\n                &lt;k2&gt;00035769&lt;/k2&gt;\n
-        \               &lt;k4&gt;41&lt;/k4&gt;\n                &lt;k5&gt;1&lt;/k5&gt;\n
-        \               &lt;k6&gt;73&lt;/k6&gt;\n                &lt;k7&gt;antioch
-        review&lt;/k7&gt;\n                &lt;k8&gt;van gogh&lt;/k8&gt;\n                &lt;k9&gt;vangogh&lt;/k9&gt;\n
-        \               &lt;k15&gt;barbaramoore&lt;/k15&gt;\n                &lt;k16&gt;moorebarbara&lt;/k16&gt;\n
+        \             &lt;/links&gt;\n              &lt;search&gt;\n                &lt;scope&gt;gale_onefilea&lt;/scope&gt;\n
+        \               &lt;scope&gt;gale_onefileg&lt;/scope&gt;\n                &lt;creatorcontrib&gt;Leslie,
+        Mitch&lt;/creatorcontrib&gt;\n                &lt;creatorcontrib&gt;Leslie&lt;/creatorcontrib&gt;\n
+        \               &lt;title&gt;What tortured the artist?(EDUCATION)(Vincent
+        van Gogh suffer of acute intermittent porphyria)(Brief article)&lt;/title&gt;\n
+        \               &lt;subject&gt;Porphyria--Research&lt;/subject&gt;\n                &lt;subject&gt;Porphyria--Analysis&lt;/subject&gt;\n
+        \               &lt;subject&gt;United States&lt;/subject&gt;\n                &lt;subject&gt;1USA&lt;/subject&gt;\n
+        \               &lt;subject&gt;Gogh, Vincent Van&lt;/subject&gt;\n                &lt;subject&gt;Observations&lt;/subject&gt;\n
+        \               &lt;subject&gt;Health aspects&lt;/subject&gt;\n                &lt;general&gt;English&lt;/general&gt;\n
+        \               &lt;general&gt;American Association for the Advancement of
+        Science&lt;/general&gt;\n                &lt;general&gt;Cengage Learning,
+        Inc.&lt;/general&gt;\n                &lt;sourceid&gt;gale_ofa&lt;/sourceid&gt;\n
+        \               &lt;recordid&gt;gale_ofa147615120&lt;/recordid&gt;\n                &lt;issn&gt;0036-8075&lt;/issn&gt;\n
+        \               &lt;issn&gt;00368075&lt;/issn&gt;\n                &lt;rsrctype&gt;article&lt;/rsrctype&gt;\n
+        \               &lt;creationdate&gt;2006&lt;/creationdate&gt;\n                &lt;recordtype&gt;article&lt;/recordtype&gt;\n
+        \               &lt;addtitle&gt;Science&lt;/addtitle&gt;\n                &lt;searchscope&gt;OneFile&lt;/searchscope&gt;\n
+        \               &lt;scope&gt;OneFile&lt;/scope&gt;\n              &lt;/search&gt;\n
+        \             &lt;sort&gt;\n                &lt;title&gt;What tortured the
+        artist?(EDUCATION)(Vincent van Gogh suffer of acute intermittent porphyria)(Brief
+        article)&lt;/title&gt;\n                &lt;author&gt;Leslie, Mitch&lt;/author&gt;\n
+        \               &lt;creationdate&gt;20060428&lt;/creationdate&gt;\n              &lt;/sort&gt;\n
+        \             &lt;facets&gt;\n                &lt;frbrgroupid&gt;6359258460248509776&lt;/frbrgroupid&gt;\n
+        \               &lt;frbrtype&gt;5&lt;/frbrtype&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
+        \               &lt;creationdate&gt;2006&lt;/creationdate&gt;\n                &lt;topic&gt;Porphyria&#x2013;Research&lt;/topic&gt;\n
+        \               &lt;topic&gt;Porphyria&#x2013;Analysis&lt;/topic&gt;\n                &lt;collection&gt;OneFile
+        (GALE)&lt;/collection&gt;\n                &lt;prefilter&gt;articles&lt;/prefilter&gt;\n
+        \               &lt;rsrctype&gt;articles&lt;/rsrctype&gt;\n                &lt;creatorcontrib&gt;Leslie,
+        Mitch&lt;/creatorcontrib&gt;\n                &lt;jtitle&gt;Science&lt;/jtitle&gt;\n
+        \               &lt;toplevel&gt;peer_reviewed&lt;/toplevel&gt;\n              &lt;/facets&gt;\n
+        \             &lt;frbr&gt;\n                &lt;t&gt;2&lt;/t&gt;\n                &lt;k1&gt;2006&lt;/k1&gt;\n
+        \               &lt;k2&gt;00368075&lt;/k2&gt;\n                &lt;k4&gt;312&lt;/k4&gt;\n
+        \               &lt;k5&gt;5773&lt;/k5&gt;\n                &lt;k6&gt;505&lt;/k6&gt;\n
+        \               &lt;k7&gt;science&lt;/k7&gt;\n                &lt;k8&gt;what
+        tortured the artist&lt;/k8&gt;\n                &lt;k9&gt;whattorturedtheartist&lt;/k9&gt;\n
+        \               &lt;k15&gt;mitchleslie&lt;/k15&gt;\n                &lt;k16&gt;lesliemitch&lt;/k16&gt;\n
         \             &lt;/frbr&gt;\n              &lt;delivery&gt;\n                &lt;delcategory&gt;Remote
         Search Resource&lt;/delcategory&gt;\n                &lt;fulltext&gt;fulltext&lt;/fulltext&gt;\n
         \             &lt;/delivery&gt;\n              &lt;ranking&gt;\n                &lt;booster1&gt;1&lt;/booster1&gt;\n
         \               &lt;booster2&gt;1&lt;/booster2&gt;\n                &lt;pcg_type&gt;aggregator&lt;/pcg_type&gt;\n
-        \             &lt;/ranking&gt;\n              &lt;addata&gt;\n                &lt;aulast&gt;Moore&lt;/aulast&gt;\n
-        \               &lt;aufirst&gt;Barbara&lt;/aufirst&gt;\n                &lt;au&gt;Moore,
-        Barbara&lt;/au&gt;\n                &lt;atitle&gt;Van Gogh&lt;/atitle&gt;\n
-        \               &lt;jtitle&gt;The Antioch Review&lt;/jtitle&gt;\n                &lt;volume&gt;41&lt;/volume&gt;\n
-        \               &lt;issue&gt;1&lt;/issue&gt;\n                &lt;spage&gt;73&lt;/spage&gt;\n
-        \               &lt;epage&gt;73&lt;/epage&gt;\n                &lt;pages&gt;73-73&lt;/pages&gt;\n
-        \               &lt;issn&gt;00035769&lt;/issn&gt;\n                &lt;genre&gt;article&lt;/genre&gt;\n
-        \               &lt;ristype&gt;JOUR&lt;/ristype&gt;\n                &lt;pub&gt;Antioch
-        Review&lt;/pub&gt;\n                &lt;url&gt;http://www.jstor.org/stable/10.2307/4611194?origin=api&lt;/url&gt;\n
-        \               &lt;lad02&gt;19830101&lt;/lad02&gt;\n                &lt;date&gt;19830101&lt;/date&gt;\n
-        \               &lt;risdate&gt;19830101&lt;/risdate&gt;\n              &lt;/addata&gt;\n
-        \           &lt;/record&gt;\n          &lt;/PrimoNMBib&gt;\n          &lt;sear:GETIT
-        GetIt2=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&quot;
-        GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Disputed%20painting%20revealed%20as%20a%20Van%20Gogh&amp;amp;rft.jtitle=New%20Scientist&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=&amp;amp;rft.aucorp=&amp;amp;rft.date=20120331&amp;amp;rft.volume=213&amp;amp;rft.issue=2858&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=7&amp;amp;rft.epage=7&amp;amp;rft.pages=7-7&amp;amp;rft.artnum=&amp;amp;rft.issn=0262-4079&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/10.1016/S0262-4079(12)60794-5&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;sciversesciencedirect_elsevier&gt;S0262-4079(12)60794-5&amp;lt;/sciversesciencedirect_elsevier&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&quot;
-        deliveryCategory=&quot;Remote Search Resource&quot;/&gt;\n          &lt;sear:LINKS&gt;\n
-        \           &lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-jstor&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh&amp;rft.jtitle=The%20Antioch%20Review&amp;rft.btitle=&amp;rft.aulast=Moore&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Moore%2C%20Barbara&amp;rft.aucorp=&amp;rft.date=19830101&amp;rft.volume=41&amp;rft.issue=1&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=73&amp;rft.epage=73&amp;rft.pages=73-73&amp;rft.artnum=&amp;rft.issn=00035769&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;jstor&gt;10.2307/4611194&lt;/jstor&gt;&amp;rft_id=info:oai/]]&gt;&lt;/sear:openurl&gt;\n
-        \           &lt;sear:backlink&gt;http://www.jstor.org/stable/10.2307/4611194?origin=api&lt;/sear:backlink&gt;\n
-        \           &lt;sear:thumbnail/&gt;\n            &lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-04-10T14%3A24%3A06IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-jstor&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Van%20Gogh&amp;rft.jtitle=The%20Antioch%20Review&amp;rft.btitle=&amp;rft.aulast=Moore&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Moore%2C%20Barbara&amp;rft.aucorp=&amp;rft.date=19830101&amp;rft.volume=41&amp;rft.issue=1&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=73&amp;rft.epage=73&amp;rft.pages=73-73&amp;rft.artnum=&amp;rft.issn=00035769&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;jstor&gt;10.2307/4611194&lt;/jstor&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article]]&gt;&lt;/sear:openurlfulltext&gt;\n
-        \         &lt;/sear:LINKS&gt;\n        &lt;/sear:DOC&gt;\n      &lt;/sear:DOCSET&gt;\n
-        \   &lt;/sear:RESULT&gt;\n  &lt;/sear:JAGROOT&gt;\n&lt;/sear:SEGMENTS&gt;\n</searchBriefReturn></searchBriefResponse></soapenv:Body></soapenv:Envelope>"
-    http_version:
-  recorded_at: Wed, 10 Apr 2013 18:24:06 GMT
-recorded_with: VCR 2.4.0
+        \             &lt;/ranking&gt;\n              &lt;addata&gt;\n                &lt;au&gt;Leslie,
+        Mitch&lt;/au&gt;\n                &lt;atitle&gt;What tortured the artist?(EDUCATION)(Vincent
+        van Gogh suffer of acute intermittent porphyria)(Brief article)&lt;/atitle&gt;\n
+        \               &lt;jtitle&gt;Science&lt;/jtitle&gt;\n                &lt;date&gt;20060428&lt;/date&gt;\n
+        \               &lt;risdate&gt;20060428&lt;/risdate&gt;\n                &lt;volume&gt;312&lt;/volume&gt;\n
+        \               &lt;issue&gt;5773&lt;/issue&gt;\n                &lt;spage&gt;505&lt;/spage&gt;\n
+        \               &lt;issn&gt;0036-8075&lt;/issn&gt;\n                &lt;genre&gt;article&lt;/genre&gt;\n
+        \               &lt;ristype&gt;JOUR&lt;/ristype&gt;\n                &lt;pub&gt;American
+        Association for the Advancement of Science&lt;/pub&gt;\n                &lt;lad01&gt;gale_ofa&lt;/lad01&gt;\n
+        \             &lt;/addata&gt;\n            &lt;/record&gt;\n          &lt;/PrimoNMBib&gt;\n
+        \       &lt;sear:GETIT deliveryCategory=&quot;Remote Search Resource&quot;
+        GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=What%20tortured%20the%20artist%3F(EDUCATION)(Vincent%20van%20Gogh%20suffer%20of%20acute%20intermittent%20porphyria)(Brief%20article)&amp;amp;rft.jtitle=Science&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=Leslie%2C%20Mitch&amp;amp;rft.aucorp=&amp;amp;rft.date=20060428&amp;amp;rft.volume=312&amp;amp;rft.issue=5773&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=505&amp;amp;rft.epage=&amp;amp;rft.pages=&amp;amp;rft.artnum=&amp;amp;rft.issn=0036-8075&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;gale_ofa&gt;147615120&amp;lt;/gale_ofa&gt;&amp;lt;grp_id&gt;6359258460248509776&amp;lt;/grp_id&gt;&amp;lt;oa&gt;&amp;lt;/oa&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&amp;amp;req.language=&quot;
+        GetIt2=&quot;&quot;/&gt;&lt;sear:LINKS&gt;&lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=What%20tortured%20the%20artist%3F(EDUCATION)(Vincent%20van%20Gogh%20suffer%20of%20acute%20intermittent%20porphyria)(Brief%20article)&amp;rft.jtitle=Science&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Leslie%2C%20Mitch&amp;rft.aucorp=&amp;rft.date=20060428&amp;rft.volume=312&amp;rft.issue=5773&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=505&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0036-8075&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;gale_ofa&gt;147615120&lt;/gale_ofa&gt;&lt;grp_id&gt;6359258460248509776&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;req.language=]]&gt;&lt;/sear:openurl&gt;&lt;sear:thumbnail/&gt;&lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=What%20tortured%20the%20artist%3F(EDUCATION)(Vincent%20van%20Gogh%20suffer%20of%20acute%20intermittent%20porphyria)(Brief%20article)&amp;rft.jtitle=Science&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Leslie%2C%20Mitch&amp;rft.aucorp=&amp;rft.date=20060428&amp;rft.volume=312&amp;rft.issue=5773&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=505&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0036-8075&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;gale_ofa&gt;147615120&lt;/gale_ofa&gt;&lt;grp_id&gt;6359258460248509776&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article&amp;req.language=]]&gt;&lt;/sear:openurlfulltext&gt;&lt;/sear:LINKS&gt;&lt;/sear:DOC&gt;\n
+        \       &lt;sear:DOC ID=&quot;482064110&quot; RANK=&quot;0.0493454&quot; NO=&quot;5&quot;
+        SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; SEARCH_ENGINE_TYPE=&quot;Primo
+        Central Search Engine&quot; LOCAL=&quot;false&quot;&gt;\n          &lt;PrimoNMBib
+        xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;\n
+        \           &lt;record&gt;\n              &lt;control&gt;\n                &lt;sourcerecordid&gt;293165368&lt;/sourcerecordid&gt;\n
+        \               &lt;sourceid&gt;gale_ofa&lt;/sourceid&gt;\n                &lt;recordid&gt;TN_gale_ofa293165368&lt;/recordid&gt;\n
+        \               &lt;sourceformat&gt;XML&lt;/sourceformat&gt;\n                &lt;sourcesystem&gt;Other&lt;/sourcesystem&gt;\n
+        \             &lt;/control&gt;\n              &lt;display&gt;\n                &lt;type&gt;article&lt;/type&gt;\n
+        \               &lt;title&gt;Beautiful mutants.(Advances / Best of the Blogs
+        / Botany)(mutated sunflowers depicted in Vincent van Gogh's oil paintings)&lt;/title&gt;\n
+        \               &lt;creator&gt;Jabr, Ferris&lt;/creator&gt;\n                &lt;ispartof&gt;Scientific
+        American, June, 2012, Vol.306(6), p.28(1)&lt;/ispartof&gt;\n                &lt;identifier&gt;&amp;lt;b&gt;ISSN:
+        &amp;lt;/b&gt;0036-8733&lt;/identifier&gt;\n                &lt;subject&gt;Sunflowers
+        -- Research ; Sunflowers -- Portrayals ; Sunflowers -- Genetic Aspects ; Dutch
+        Painters -- Works ; Gene Mutation -- Research ; Plant Mutation -- Research&lt;/subject&gt;\n
+        \               &lt;description&gt;Researchers from the University of Georgia
+        attributed the floral arrangements of sunflowers depicted in Vincent Van Gogh's
+        oil paintings from the late 1880s to mutations of the HaCYC2c gene. Instead
+        of showing yellow petals encircling a dark whorl of seeds, Van Gogh's paintings
+        portray doubled-flowered blooms that have abundant small yellow petals.&lt;/description&gt;\n
+        \               &lt;language&gt;English&lt;/language&gt;\n                &lt;source&gt;Cengage
+        Learning, Inc.&lt;/source&gt;\n                &lt;lds50&gt;peer_reviewed&lt;/lds50&gt;\n
+        \               &lt;version&gt;2&lt;/version&gt;\n              &lt;/display&gt;\n
+        \             &lt;links&gt;\n                &lt;openurl&gt;$$Topenurl_article&lt;/openurl&gt;\n
+        \               &lt;openurlfulltext&gt;$$Topenurlfull_article&lt;/openurlfulltext&gt;\n
+        \             &lt;/links&gt;\n              &lt;search&gt;\n                &lt;scope&gt;gale_onefilea&lt;/scope&gt;\n
+        \               &lt;scope&gt;gale_onefileg&lt;/scope&gt;\n                &lt;creatorcontrib&gt;Jabr,
+        Ferris&lt;/creatorcontrib&gt;\n                &lt;title&gt;Beautiful mutants.(Advances
+        / Best of the Blogs / Botany)(mutated sunflowers depicted in Vincent van Gogh's
+        oil paintings)&lt;/title&gt;\n                &lt;description&gt;Researchers
+        from the University of Georgia attributed the floral arrangements of sunflowers
+        depicted in Vincent Van Gogh's oil paintings from the late 1880s to mutations
+        of the HaCYC2c gene. Instead of showing yellow petals encircling a dark whorl
+        of seeds, Van Gogh's paintings portray doubled-flowered blooms that have abundant
+        small yellow petals.&lt;/description&gt;\n                &lt;subject&gt;Sunflowers--Research&lt;/subject&gt;\n
+        \               &lt;subject&gt;Sunflowers--Portrayals&lt;/subject&gt;\n                &lt;subject&gt;Sunflowers--Genetic
+        aspects&lt;/subject&gt;\n                &lt;subject&gt;Dutch painters--Works&lt;/subject&gt;\n
+        \               &lt;subject&gt;Gene mutation--Research&lt;/subject&gt;\n                &lt;subject&gt;Plant
+        mutation--Research&lt;/subject&gt;\n                &lt;subject&gt;United
+        States&lt;/subject&gt;\n                &lt;subject&gt;1USA&lt;/subject&gt;\n
+        \               &lt;subject&gt;Gogh, Vincent Van&lt;/subject&gt;\n                &lt;subject&gt;Works&lt;/subject&gt;\n
+        \               &lt;general&gt;English&lt;/general&gt;\n                &lt;general&gt;Scientific
+        American, Inc.&lt;/general&gt;\n                &lt;general&gt;Cengage Learning,
+        Inc.&lt;/general&gt;\n                &lt;sourceid&gt;gale_ofa&lt;/sourceid&gt;\n
+        \               &lt;recordid&gt;gale_ofa293165368&lt;/recordid&gt;\n                &lt;issn&gt;0036-8733&lt;/issn&gt;\n
+        \               &lt;issn&gt;00368733&lt;/issn&gt;\n                &lt;rsrctype&gt;article&lt;/rsrctype&gt;\n
+        \               &lt;creationdate&gt;2012&lt;/creationdate&gt;\n                &lt;recordtype&gt;article&lt;/recordtype&gt;\n
+        \               &lt;addtitle&gt;Scientific American&lt;/addtitle&gt;\n                &lt;searchscope&gt;OneFile&lt;/searchscope&gt;\n
+        \               &lt;scope&gt;OneFile&lt;/scope&gt;\n              &lt;/search&gt;\n
+        \             &lt;sort&gt;\n                &lt;title&gt;Beautiful mutants.(Advances
+        / Best of the Blogs / Botany)(mutated sunflowers depicted in Vincent van Gogh's
+        oil paintings)&lt;/title&gt;\n                &lt;author&gt;Jabr, Ferris&lt;/author&gt;\n
+        \               &lt;creationdate&gt;20120601&lt;/creationdate&gt;\n              &lt;/sort&gt;\n
+        \             &lt;facets&gt;\n                &lt;frbrgroupid&gt;5768430088859704746&lt;/frbrgroupid&gt;\n
+        \               &lt;frbrtype&gt;5&lt;/frbrtype&gt;\n                &lt;language&gt;eng&lt;/language&gt;\n
+        \               &lt;creationdate&gt;2012&lt;/creationdate&gt;\n                &lt;topic&gt;Sunflowers&#x2013;Research&lt;/topic&gt;\n
+        \               &lt;topic&gt;Sunflowers&#x2013;Portrayals&lt;/topic&gt;\n
+        \               &lt;topic&gt;Sunflowers&#x2013;Genetic Aspects&lt;/topic&gt;\n
+        \               &lt;topic&gt;Dutch Painters&#x2013;Works&lt;/topic&gt;\n                &lt;topic&gt;Gene
+        Mutation&#x2013;Research&lt;/topic&gt;\n                &lt;topic&gt;Plant
+        Mutation&#x2013;Research&lt;/topic&gt;\n                &lt;collection&gt;OneFile
+        (GALE)&lt;/collection&gt;\n                &lt;prefilter&gt;articles&lt;/prefilter&gt;\n
+        \               &lt;rsrctype&gt;articles&lt;/rsrctype&gt;\n                &lt;creatorcontrib&gt;Jabr,
+        Ferris&lt;/creatorcontrib&gt;\n                &lt;jtitle&gt;Scientific American&lt;/jtitle&gt;\n
+        \               &lt;toplevel&gt;peer_reviewed&lt;/toplevel&gt;\n              &lt;/facets&gt;\n
+        \             &lt;frbr&gt;\n                &lt;t&gt;2&lt;/t&gt;\n                &lt;k1&gt;2012&lt;/k1&gt;\n
+        \               &lt;k2&gt;00368733&lt;/k2&gt;\n                &lt;k4&gt;306&lt;/k4&gt;\n
+        \               &lt;k5&gt;6&lt;/k5&gt;\n                &lt;k6&gt;28&lt;/k6&gt;\n
+        \               &lt;k7&gt;scientific american&lt;/k7&gt;\n                &lt;k8&gt;beautiful
+        mutants&lt;/k8&gt;\n                &lt;k9&gt;beautifulmutants&lt;/k9&gt;\n
+        \               &lt;k15&gt;ferrisjabr&lt;/k15&gt;\n                &lt;k16&gt;jabrferris&lt;/k16&gt;\n
+        \             &lt;/frbr&gt;\n              &lt;delivery&gt;\n                &lt;delcategory&gt;Remote
+        Search Resource&lt;/delcategory&gt;\n                &lt;fulltext&gt;fulltext&lt;/fulltext&gt;\n
+        \             &lt;/delivery&gt;\n              &lt;ranking&gt;\n                &lt;booster1&gt;1&lt;/booster1&gt;\n
+        \               &lt;booster2&gt;1&lt;/booster2&gt;\n                &lt;pcg_type&gt;aggregator&lt;/pcg_type&gt;\n
+        \             &lt;/ranking&gt;\n              &lt;addata&gt;\n                &lt;au&gt;Jabr,
+        Ferris&lt;/au&gt;\n                &lt;atitle&gt;Beautiful mutants.(Advances
+        / Best of the Blogs / Botany)(mutated sunflowers depicted in Vincent van Gogh's
+        oil paintings)&lt;/atitle&gt;\n                &lt;jtitle&gt;Scientific American&lt;/jtitle&gt;\n
+        \               &lt;date&gt;20120601&lt;/date&gt;\n                &lt;risdate&gt;20120601&lt;/risdate&gt;\n
+        \               &lt;volume&gt;306&lt;/volume&gt;\n                &lt;issue&gt;6&lt;/issue&gt;\n
+        \               &lt;spage&gt;28&lt;/spage&gt;\n                &lt;issn&gt;0036-8733&lt;/issn&gt;\n
+        \               &lt;genre&gt;article&lt;/genre&gt;\n                &lt;ristype&gt;JOUR&lt;/ristype&gt;\n
+        \               &lt;abstract&gt;Researchers from the University of Georgia
+        attributed the floral arrangements of sunflowers depicted in Vincent Van Gogh's
+        oil paintings from the late 1880s to mutations of the HaCYC2c gene. Instead
+        of showing yellow petals encircling a dark whorl of seeds, Van Gogh's paintings
+        portray doubled-flowered blooms that have abundant small yellow petals.&lt;/abstract&gt;\n
+        \               &lt;pub&gt;Scientific American, Inc.&lt;/pub&gt;\n                &lt;lad01&gt;gale_ofa&lt;/lad01&gt;\n
+        \             &lt;/addata&gt;\n            &lt;/record&gt;\n          &lt;/PrimoNMBib&gt;\n
+        \       &lt;sear:GETIT deliveryCategory=&quot;Remote Search Resource&quot;
+        GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;amp;rft.genre=article&amp;amp;rft.atitle=Beautiful%20mutants.(Advances%20/%20Best%20of%20the%20Blogs%20/%20Botany)(mutated%20sunflowers%20depicted%20in%20Vincent%20van%20Gogh%27s%20oil%20paintings)&amp;amp;rft.jtitle=Scientific%20American&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=Jabr%2C%20Ferris&amp;amp;rft.aucorp=&amp;amp;rft.date=20120601&amp;amp;rft.volume=306&amp;amp;rft.issue=6&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=28&amp;amp;rft.epage=&amp;amp;rft.pages=&amp;amp;rft.artnum=&amp;amp;rft.issn=0036-8733&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;gale_ofa&gt;293165368&amp;lt;/gale_ofa&gt;&amp;lt;grp_id&gt;5768430088859704746&amp;lt;/grp_id&gt;&amp;lt;oa&gt;&amp;lt;/oa&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&amp;amp;req.language=&quot;
+        GetIt2=&quot;&quot;/&gt;&lt;sear:LINKS&gt;&lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Beautiful%20mutants.(Advances%20/%20Best%20of%20the%20Blogs%20/%20Botany)(mutated%20sunflowers%20depicted%20in%20Vincent%20van%20Gogh%27s%20oil%20paintings)&amp;rft.jtitle=Scientific%20American&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Jabr%2C%20Ferris&amp;rft.aucorp=&amp;rft.date=20120601&amp;rft.volume=306&amp;rft.issue=6&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=28&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0036-8733&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;gale_ofa&gt;293165368&lt;/gale_ofa&gt;&lt;grp_id&gt;5768430088859704746&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;req.language=]]&gt;&lt;/sear:openurl&gt;&lt;sear:thumbnail/&gt;&lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A33IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Beautiful%20mutants.(Advances%20/%20Best%20of%20the%20Blogs%20/%20Botany)(mutated%20sunflowers%20depicted%20in%20Vincent%20van%20Gogh%27s%20oil%20paintings)&amp;rft.jtitle=Scientific%20American&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Jabr%2C%20Ferris&amp;rft.aucorp=&amp;rft.date=20120601&amp;rft.volume=306&amp;rft.issue=6&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=28&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0036-8733&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;gale_ofa&gt;293165368&lt;/gale_ofa&gt;&lt;grp_id&gt;5768430088859704746&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article&amp;req.language=]]&gt;&lt;/sear:openurlfulltext&gt;&lt;/sear:LINKS&gt;&lt;/sear:DOC&gt;\n
+        \       \n        \n        \n        \n        \n      &lt;/sear:DOCSET&gt;\n
+        \   &lt;/sear:RESULT&gt;\n    &lt;sear:searchToken&gt;0&lt;/sear:searchToken&gt;\n
+        \ &lt;/sear:JAGROOT&gt;&lt;/sear:SEGMENTS&gt;</searchBriefReturn></ns1:searchBriefResponse></soapenv:Body></soapenv:Envelope>"
+    http_version: 
+  recorded_at: Thu, 05 Jun 2014 16:49:33 GMT
+recorded_with: VCR 2.5.0

--- a/test/vcr_cassettes/search_primo_central_mla.yml
+++ b/test/vcr_cassettes/search_primo_central_mla.yml
@@ -1,0 +1,213 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://primo-fe1.library.nd.edu:1701/PrimoWebServices/services/searcher
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="http://primo-fe1.library.nd.edu:1701/PrimoWebServices/services/searcher"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:searchBrief><request><![CDATA[<searchRequest
+        xmlns="http://www.exlibris.com/primo/xsd/wsRequest" xmlns:uic="http://www.exlibris.com/primo/xsd/primoview/uicomponents"><PrimoSearchRequest
+        xmlns="http://www.exlibris.com/primo/xsd/search/request"><QueryTerms><BoolOpeator>AND</BoolOpeator><QueryTerm><IndexField>rid</IndexField><PrecisionOperator>exact</PrecisionOperator><Value>mla2012444463</Value></QueryTerm></QueryTerms><StartIndex>1</StartIndex><BulkSize>5</BulkSize><DidUMeanEnabled>false</DidUMeanEnabled><Locations><uic:Location
+        type="adaptor" value="primo_central_multiple_fe"/></Locations></PrimoSearchRequest><institution>NDU</institution><onCampus>true</onCampus></searchRequest>]]></request></wsdl:searchBrief></env:Body></env:Envelope>
+    headers:
+      Soapaction:
+      - '"searchBrief"'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '1052'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - text/xml;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 05 Jun 2014 16:49:32 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><ns1:searchBriefResponse soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns1="http://primo-fe1.library.nd.edu:1701/PrimoWebServices/services/searcher"><searchBriefReturn xsi:type="soapenc:string" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">&lt;sear:SEGMENTS xmlns:sear=&quot;http://www.exlibrisgroup.com/xsd/jaguar/search&quot;&gt;&lt;sear:JAGROOT&gt;
+            &lt;sear:RESULT&gt;
+              &lt;sear:QUERYTRANSFORMS/&gt;
+              &lt;sear:FACETLIST ACCURATE_COUNTERS=&quot;true&quot;&gt;
+                &lt;sear:FACET NAME=&quot;creator&quot; COUNT=&quot;2&quot;&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;Taylor, Matthew&quot; VALUE=&quot;1&quot;/&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;Taylor, M.&quot; VALUE=&quot;1&quot;/&gt;
+                &lt;/sear:FACET&gt;
+                &lt;sear:FACET NAME=&quot;lang&quot; COUNT=&quot;1&quot;&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;eng&quot; VALUE=&quot;1&quot;/&gt;
+                &lt;/sear:FACET&gt;
+                &lt;sear:FACET NAME=&quot;rtype&quot; COUNT=&quot;2&quot;&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;articles&quot; VALUE=&quot;1&quot;/&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;text_resources&quot; VALUE=&quot;1&quot;/&gt;
+                &lt;/sear:FACET&gt;
+                &lt;sear:FACET NAME=&quot;topic&quot; COUNT=&quot;6&quot;&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;Dramatic Arts&quot; VALUE=&quot;1&quot;/&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot; Film&quot; VALUE=&quot;1&quot;/&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;Movie Directors&quot; VALUE=&quot;1&quot;/&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot; The Hunt&quot; VALUE=&quot;1&quot;/&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot; Vinterberg, Thomas(1969- )&quot; VALUE=&quot;1&quot;/&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot; Jagten(2012)&quot; VALUE=&quot;1&quot;/&gt;
+                &lt;/sear:FACET&gt;
+                &lt;sear:FACET NAME=&quot;tlevel&quot; COUNT=&quot;1&quot;&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;online_resources&quot; VALUE=&quot;1&quot;/&gt;
+                &lt;/sear:FACET&gt;
+                &lt;sear:FACET NAME=&quot;pfilter&quot; COUNT=&quot;1&quot;&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;articles&quot; VALUE=&quot;1&quot;/&gt;
+                &lt;/sear:FACET&gt;
+                &lt;sear:FACET NAME=&quot;creationdate&quot; COUNT=&quot;1&quot;&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;2012&quot; VALUE=&quot;1&quot;/&gt;
+                &lt;/sear:FACET&gt;
+                &lt;sear:FACET NAME=&quot;domain&quot; COUNT=&quot;2&quot;&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;MLA International Bibliography&quot; VALUE=&quot;1&quot;/&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;OneFile (GALE)&quot; VALUE=&quot;1&quot;/&gt;
+                &lt;/sear:FACET&gt;
+                &lt;sear:FACET NAME=&quot;jtitle&quot; COUNT=&quot;1&quot;&gt;
+                  &lt;sear:FACET_VALUES KEY=&quot;Sight and Sound&quot; VALUE=&quot;1&quot;/&gt;
+                &lt;/sear:FACET&gt;
+              &lt;/sear:FACETLIST&gt;
+              &lt;sear:DOCSET HIT_TIME=&quot;10&quot; TOTALHITS=&quot;1&quot; FIRSTHIT=&quot;1&quot; LASTHIT=&quot;5&quot; TOTAL_TIME=&quot;35&quot;&gt;
+                &lt;sear:DOC ID=&quot;359046088&quot; RANK=&quot;0.07&quot; NO=&quot;1&quot; SEARCH_ENGINE=&quot;PrimoCentralThirdNode&quot; SEARCH_ENGINE_TYPE=&quot;Primo Central Search Engine&quot; LOCAL=&quot;false&quot;&gt;
+                  &lt;PrimoNMBib xmlns=&quot;http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib&quot;&gt;
+                    &lt;record&gt;
+                      &lt;control&gt;
+                        &lt;sourcerecordid&gt;2012444463&lt;/sourcerecordid&gt;
+                        &lt;sourceid&gt;mla&lt;/sourceid&gt;
+                        &lt;recordid&gt;TN_mla2012444463&lt;/recordid&gt;
+                        &lt;sourcesystem&gt;Other&lt;/sourcesystem&gt;
+                      &lt;/control&gt;
+                      &lt;display&gt;
+                        &lt;type&gt;article&lt;/type&gt;
+                        &lt;title&gt;Something Rotten in Denmark&lt;/title&gt;
+                        &lt;creator&gt;Taylor, Matthew&lt;/creator&gt;
+                        &lt;ispartof&gt;Sight and Sound, 2012 Dec, Vol.22(12), p.16&lt;/ispartof&gt;
+                        &lt;identifier&gt;&amp;lt;b&gt;ISSN: &amp;lt;/b&gt;0037-4806&lt;/identifier&gt;
+                        &lt;subject&gt;Dramatic Arts ;  Film ;  Vinterberg, Thomas(1969- ) ;  Jagten(2012) ;  The Hunt&lt;/subject&gt;
+                        &lt;language&gt;English&lt;/language&gt;
+                        &lt;source&gt;MLA International Bibliography&amp;lt;img src=&quot;http://exlibris-pub.s3.amazonaws.com/mlalogo_001.jpg&quot; style=&quot;vertical-align:middle;margin-left:7px&quot;&gt;&lt;/source&gt;
+                        &lt;lds42&gt;english&lt;/lds42&gt;
+                        &lt;version&gt;4&lt;/version&gt;
+                      &lt;/display&gt;
+                      &lt;links&gt;
+                        &lt;openurl&gt;$$Topenurl_article&lt;/openurl&gt;
+                        &lt;thumbnail&gt;$$TPCgoogle_thumb&lt;/thumbnail&gt;
+                        &lt;thumbnail&gt;$$TPCamazon_thumb&lt;/thumbnail&gt;
+                        &lt;openurlfulltext&gt;$$Topenurlfull_article&lt;/openurlfulltext&gt;
+                      &lt;/links&gt;
+                      &lt;search&gt;
+                        &lt;creatorcontrib&gt;Taylor, Matthew&lt;/creatorcontrib&gt;
+                        &lt;title&gt;Something Rotten in Denmark&lt;/title&gt;
+                        &lt;subject&gt;dramatic arts&lt;/subject&gt;
+                        &lt;subject&gt;film&lt;/subject&gt;
+                        &lt;subject&gt;Vinterberg, Thomas&amp;lt;&amp;lt;1969- &gt;&gt;&lt;/subject&gt;
+                        &lt;subject&gt;Jagten&amp;lt;&amp;lt;2012&gt;&gt;&lt;/subject&gt;
+                        &lt;subject&gt;The Hunt&lt;/subject&gt;
+                        &lt;general&gt;English&lt;/general&gt;
+                        &lt;general&gt;2012-8-4672&lt;/general&gt;
+                        &lt;sourceid&gt;mla&lt;/sourceid&gt;
+                        &lt;recordid&gt;mla2012444463&lt;/recordid&gt;
+                        &lt;issn&gt;0037-4806&lt;/issn&gt;
+                        &lt;issn&gt;00374806&lt;/issn&gt;
+                        &lt;rsrctype&gt;article&lt;/rsrctype&gt;
+                        &lt;creationdate&gt;2012&lt;/creationdate&gt;
+                        &lt;addtitle&gt;Sight and Sound&lt;/addtitle&gt;
+                        &lt;searchscope&gt;mla&lt;/searchscope&gt;
+                        &lt;searchscope&gt;mlab_bib&lt;/searchscope&gt;
+                        &lt;searchscope&gt;mlab_gale_lrc_mlaib&lt;/searchscope&gt;
+                        &lt;searchscope&gt;mlab_gale_mlaib&lt;/searchscope&gt;
+                        &lt;searchscope&gt;mlab_ebsco&lt;/searchscope&gt;
+                        &lt;searchscope&gt;mlab_proquest_c_h&lt;/searchscope&gt;
+                        &lt;searchscope&gt;mlab_proquest_lit&lt;/searchscope&gt;
+                        &lt;searchscope&gt;mlab_csa&lt;/searchscope&gt;
+                        &lt;searchscope&gt;mlab&lt;/searchscope&gt;
+                        &lt;scope&gt;mla&lt;/scope&gt;
+                        &lt;scope&gt;mlab_bib&lt;/scope&gt;
+                        &lt;scope&gt;mlab_gale_lrc_mlaib&lt;/scope&gt;
+                        &lt;scope&gt;mlab_gale_mlaib&lt;/scope&gt;
+                        &lt;scope&gt;mlab_ebsco&lt;/scope&gt;
+                        &lt;scope&gt;mlab_proquest_c_h&lt;/scope&gt;
+                        &lt;scope&gt;mlab_proquest_lit&lt;/scope&gt;
+                        &lt;scope&gt;mlab_csa&lt;/scope&gt;
+                        &lt;scope&gt;mlab&lt;/scope&gt;
+                        &lt;lsr40&gt;16&lt;/lsr40&gt;
+                      &lt;/search&gt;
+                      &lt;sort&gt;
+                        &lt;title&gt;Something Rotten in Denmark&lt;/title&gt;
+                        &lt;creationdate&gt;20120000&lt;/creationdate&gt;
+                        &lt;author&gt;Taylor, Matthew&lt;/author&gt;
+                      &lt;/sort&gt;
+                      &lt;facets&gt;
+                        &lt;frbrgroupid&gt;5810529816792308232&lt;/frbrgroupid&gt;
+                        &lt;frbrtype&gt;5&lt;/frbrtype&gt;
+                        &lt;language&gt;eng&lt;/language&gt;
+                        &lt;creationdate&gt;2012&lt;/creationdate&gt;
+                        &lt;topic&gt;Dramatic Arts&lt;/topic&gt;
+                        &lt;topic&gt;Film&lt;/topic&gt;
+                        &lt;topic&gt;Vinterberg, Thomas(1969- )&lt;/topic&gt;
+                        &lt;topic&gt;Jagten(2012)&lt;/topic&gt;
+                        &lt;topic&gt;The Hunt&lt;/topic&gt;
+                        &lt;collection&gt;MLA International Bibliography&lt;/collection&gt;
+                        &lt;prefilter&gt;articles&lt;/prefilter&gt;
+                        &lt;rsrctype&gt;articles&lt;/rsrctype&gt;
+                        &lt;creatorcontrib&gt;Taylor, Matthew&lt;/creatorcontrib&gt;
+                        &lt;jtitle&gt;Sight and Sound&lt;/jtitle&gt;
+                      &lt;/facets&gt;
+                      &lt;frbr&gt;
+                        &lt;t&gt;2&lt;/t&gt;
+                        &lt;k1&gt;2012&lt;/k1&gt;
+                        &lt;k2&gt;00374806&lt;/k2&gt;
+                        &lt;k4&gt;22&lt;/k4&gt;
+                        &lt;k5&gt;12&lt;/k5&gt;
+                        &lt;k6&gt;16&lt;/k6&gt;
+                        &lt;k7&gt;sight sound&lt;/k7&gt;
+                        &lt;k8&gt;something rotten in denmark&lt;/k8&gt;
+                        &lt;k9&gt;somethingrottenindenmark&lt;/k9&gt;
+                        &lt;k15&gt;matthewtaylor&lt;/k15&gt;
+                        &lt;k16&gt;taylormatthew&lt;/k16&gt;
+                      &lt;/frbr&gt;
+                      &lt;delivery&gt;
+                        &lt;delcategory&gt;Remote Search Resource&lt;/delcategory&gt;
+                        &lt;fulltext&gt;fulltext&lt;/fulltext&gt;
+                      &lt;/delivery&gt;
+                      &lt;ranking&gt;
+                        &lt;booster1&gt;1&lt;/booster1&gt;
+                        &lt;booster2&gt;1&lt;/booster2&gt;
+                        &lt;pcg_type&gt;publisher&lt;/pcg_type&gt;
+                      &lt;/ranking&gt;
+                      &lt;addata&gt;
+                        &lt;au&gt;Taylor, Matthew&lt;/au&gt;
+                        &lt;atitle&gt;Something Rotten in Denmark&lt;/atitle&gt;
+                        &lt;jtitle&gt;Sight and Sound&lt;/jtitle&gt;
+                        &lt;date&gt;2012&lt;/date&gt;
+                        &lt;risdate&gt;2012&lt;/risdate&gt;
+                        &lt;volume&gt;22&lt;/volume&gt;
+                        &lt;issue&gt;12&lt;/issue&gt;
+                        &lt;spage&gt;16&lt;/spage&gt;
+                        &lt;issn&gt;0037-4806&lt;/issn&gt;
+                        &lt;format&gt;journal&lt;/format&gt;
+                        &lt;ristype&gt;JOUR&lt;/ristype&gt;
+                      &lt;/addata&gt;
+                    &lt;/record&gt;
+                  &lt;/PrimoNMBib&gt;
+                &lt;sear:GETIT deliveryCategory=&quot;Remote Search Resource&quot; GetIt1=&quot;http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;amp;ctx_enc=info:ofi/enc:UTF-8&amp;amp;ctx_tim=2014-06-05T12%3A49%3A32IST&amp;amp;url_ver=Z39.88-2004&amp;amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-mla&amp;amp;rft_val_fmt=info:ofi/fmt:kev:mtx:journal&amp;amp;rft.genre=&amp;amp;rft.atitle=Something%20Rotten%20in%20Denmark&amp;amp;rft.jtitle=Sight%20and%20Sound&amp;amp;rft.btitle=&amp;amp;rft.aulast=&amp;amp;rft.auinit=&amp;amp;rft.auinit1=&amp;amp;rft.auinitm=&amp;amp;rft.ausuffix=&amp;amp;rft.au=Taylor%2C%20Matthew&amp;amp;rft.aucorp=&amp;amp;rft.date=2012&amp;amp;rft.volume=22&amp;amp;rft.issue=12&amp;amp;rft.part=&amp;amp;rft.quarter=&amp;amp;rft.ssn=&amp;amp;rft.spage=16&amp;amp;rft.epage=&amp;amp;rft.pages=&amp;amp;rft.artnum=&amp;amp;rft.issn=0037-4806&amp;amp;rft.eissn=&amp;amp;rft.isbn=&amp;amp;rft.sici=&amp;amp;rft.coden=&amp;amp;rft_id=info:doi/&amp;amp;rft.object_id=&amp;amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;amp;svc.fulltext=&amp;amp;rft.eisbn=&amp;amp;rft_dat=&amp;lt;mla&gt;2012444463&amp;lt;/mla&gt;&amp;lt;grp_id&gt;5810529816792308232&amp;lt;/grp_id&gt;&amp;lt;oa&gt;&amp;lt;/oa&gt;&amp;amp;rft_id=info:oai/&amp;amp;template=openurlfull_article&amp;amp;req.language=&quot; GetIt2=&quot;&quot;/&gt;&lt;sear:LINKS&gt;&lt;sear:openurl&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A32IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-mla&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:journal&amp;rft.genre=&amp;rft.atitle=Something%20Rotten%20in%20Denmark&amp;rft.jtitle=Sight%20and%20Sound&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Taylor%2C%20Matthew&amp;rft.aucorp=&amp;rft.date=2012&amp;rft.volume=22&amp;rft.issue=12&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=16&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0037-4806&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft.eisbn=&amp;rft_dat=&lt;mla&gt;2012444463&lt;/mla&gt;&lt;grp_id&gt;5810529816792308232&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;req.language=]]&gt;&lt;/sear:openurl&gt;&lt;sear:thumbnail&gt;http://books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&amp;amp;jscmd=viewapi&amp;amp;callback=updateGBSCover&lt;/sear:thumbnail&gt;&lt;sear:thumbnail&gt;http://images.amazon.com/images/P/.01._SSTHUM_.jpg&lt;/sear:thumbnail&gt;&lt;sear:openurlfulltext&gt;&lt;![CDATA[http://findtext.library.nd.edu:8889/ndu_local?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2014-06-05T12%3A49%3A32IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-mla&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:journal&amp;rft.genre=&amp;rft.atitle=Something%20Rotten%20in%20Denmark&amp;rft.jtitle=Sight%20and%20Sound&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Taylor%2C%20Matthew&amp;rft.aucorp=&amp;rft.date=2012&amp;rft.volume=22&amp;rft.issue=12&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=16&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0037-4806&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=&amp;rft.eisbn=&amp;rft_dat=&lt;mla&gt;2012444463&lt;/mla&gt;&lt;grp_id&gt;5810529816792308232&lt;/grp_id&gt;&lt;oa&gt;&lt;/oa&gt;&amp;rft_id=info:oai/&amp;template=openurlfull_article&amp;req.language=]]&gt;&lt;/sear:openurlfulltext&gt;&lt;/sear:LINKS&gt;&lt;/sear:DOC&gt;
+              &lt;/sear:DOCSET&gt;
+            &lt;/sear:RESULT&gt;
+            &lt;sear:searchToken&gt;0&lt;/sear:searchToken&gt;
+          &lt;/sear:JAGROOT&gt;&lt;/sear:SEGMENTS&gt;</searchBriefReturn></ns1:searchBriefResponse></soapenv:Body></soapenv:Envelope>
+    http_version: 
+  recorded_at: Thu, 05 Jun 2014 16:49:33 GMT
+recorded_with: VCR 2.5.0


### PR DESCRIPTION
We ran into an issue where Savon was incorrectly parsing the SOAP response from Primo by decoding escaped entities incorrectly.

This fix updates Savon, which removes the need for the extra escaping done in lib/exlibris/primo/web_service/response/base.rb.  It also removes the need for using inner_html instead of inner_text to read attributes.  Since &lt; symbols are now properly escaped, inner_text returns the expected value, while inner_html will actually escape the less than and greater than symbols.

We noticed the problem on MLA records from Primo Central, because the MLA source comes through with an image tag that was escaped properly by Primo, but modified in the body by Savon so the raw xml given to nokogiri looked like this: `<source>MLA International Bibliography<img src="http://exlibris-pub.s3.amazonaws.com/mlalogo_001.jpg" style="vertical-align:middle;margin-left:7px"></source>`

Nokogiri interpreted <img as a new element, which ended up breaking the nesting and xpath parsing.
