### PR TITLE
Fix exception when loading holdings for records with missing control fields

### DIFF
--- a/lib/exlibris/primo/pnx/dedup_mgr.rb
+++ b/lib/exlibris/primo/pnx/dedup_mgr.rb
@@ -59,8 +59,10 @@ module Exlibris
               if !instance_variable_defined?(variable_name)
                 if dedupmgr?
                   value = map_values_to_origins(control_attribute)
-                else
+                elsif respond_to?(control_attribute)
                   value = {recordid => send(control_attribute)}
+                else
+                  value = {recordid => nil}
                 end
                 instance_variable_set(variable_name, value)
               end

--- a/lib/exlibris/primo/pnx/dedup_mgr.rb
+++ b/lib/exlibris/primo/pnx/dedup_mgr.rb
@@ -1,9 +1,9 @@
 module Exlibris
   module Primo
     module Pnx
-      # 
+      #
       # Handle PNX dedupmgr elements
-      # 
+      #
       module DedupMgr
 
         def self.included(klass)
@@ -55,8 +55,16 @@ module Exlibris
           if(duplicated_control_attributes.include? method)
             control_attribute = method.id2name.singularize
             self.class.send(:define_method, method) do
-              eval("@#{method} ||= (dedupmgr?) ?
-                map_values_to_origins(\"#{control_attribute}\") : {recordid => #{control_attribute}}")
+              variable_name = "@#{method}"
+              if !instance_variable_defined?(variable_name)
+                if dedupmgr?
+                  value = map_values_to_origins(control_attribute)
+                else
+                  value = {recordid => send(control_attribute)}
+                end
+                instance_variable_set(variable_name, value)
+              end
+              instance_variable_get(variable_name)
             end
             send method, *args, &block
           else

--- a/test/pnx/holdings_test.rb
+++ b/test/pnx/holdings_test.rb
@@ -1,6 +1,20 @@
 module Pnx
   require 'test_helper'
   class HoldingsTest < Test::Unit::TestCase
+    def test_load_other_holdings
+      reset_primo_configuration
+      record = Exlibris::Primo::Record.new(:raw_xml => record_other_source_xml)
+      holdings = record.holdings.collect { | h | }
+      assert record.respond_to? :display_title
+      assert record.respond_to? :recordid
+      assert_not_nil record.holdings
+      holding = record.holdings.first
+      assert_equal("nduspec_eadRBSC-MSNEA0506", holding.record_id)
+      assert_nil(holding.original_source_id)
+      assert_equal("RBSC-MSNEA0506", holding.source_record_id)
+      assert_nil(holding.ils_api_id)
+    end
+
     def test_holdings
       reset_primo_configuration
       record = Exlibris::Primo::Record.new(:raw_xml => record_xml)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -561,6 +561,10 @@ class Test::Unit::TestCase
     "</record>"
   end
 
+  def record_other_source_xml
+    File.read(File.expand_path("../xml/record_other_sourcesystem.xml",  __FILE__))
+  end
+
   def record_invalid_frbr_xml
     "<record>"+
     "<control>"+

--- a/test/xml/record_other_sourcesystem.xml
+++ b/test/xml/record_other_sourcesystem.xml
@@ -1,0 +1,207 @@
+<record>
+  <control>
+    <sourcerecordid>RBSC-MSNEA0506</sourcerecordid>
+    <sourceid>nduspec_ead</sourceid>
+    <recordid>nduspec_eadRBSC-MSNEA0506</recordid>
+    <sourceformat>XML</sourceformat>
+    <sourcesystem>Other</sourcesystem>
+  </control>
+  <display>
+    <type>archival</type>
+    <title>Graves family shipping papers</title>
+    <creator>William Graves, Jr, 1811 - 1877)</creator>
+    <format>About 2500 manuscripts;</format>
+    <format>5 containers;</format>
+    <format>2.5 linear feet</format>
+    <subject>Newburyport [Mass.] -- Business, industries, and trades -- Shipping</subject>
+    <subject>Shipping -- Massachusetts</subject>
+    <subject>Ships -- Cargo</subject>
+    <subject>Massachusetts -- Commerce</subject>
+    <subject>India -- Commerce -- United States</subject>
+    <subject>Great Britain -- Commerce -- United States</subject>
+    <subject>Graves, William, Jr. [1811-1877]</subject>
+    <subject>Graves, William [1785-1851]</subject>
+    <subject>George West [Ship]</subject>
+    <subject>Castilian [Ship]</subject>
+    <subject>Josiah L. Hale [Ship]</subject>
+    <description>About 2500 manuscript business papers of the Graves family, captains and shipowners of Newburyport, Massachusetts, with an emphasis on the incoming correspondence of William Graves, Jr. (1811-1877) and records of his ships Castilian, George West, and Josiah L. Hale.</description>
+    <language>Collection material in English</language>
+    <relation>Additional shipping records of William Graves, Jr. (the William Graves, Jr. Papers) are located in the Phillips Library of the Peabody Essex Museum, Salem, Massachusetts. A letter book of William Graves, Jr. (William Graves Letter Book), with correspondence dating from 1846 to 1860, is held in the Baker Library at the Harvard Business School, Cambridge, Massachusetts.</relation>
+    <coverage>1812-1877</coverage>
+    <coverage>(bulk 1850-1875)</coverage>
+    <availlibrary>$$INDU$$LHESB$$1Special Coll.$$2(MSN/EA 0506) [In-Library Use Only]$$Savailable</availlibrary>
+    <citation>Graves Family Shipping Papers, Department of Special Collections, Hesburgh Libraries of Notre Dame.</citation>
+    <lds01>Aquisition Information: The Graves Family Shipping Papers were purchased by the Hesburgh Libraries in 2011, from Michael Brown Rare Books of Philadelphia (List 112, Item 21). Arranged and described 2011, by Sara Szakaly. Finding aid 2011-12, by Sara Szakaly and George Rugg.</lds01>
+    <lds01>Related Materials: Additional shipping records of William Graves, Jr. (the William Graves, Jr. Papers) are located in the Phillips Library of the Peabody Essex Museum, Salem, Massachusetts. A letter book of William Graves, Jr. (William Graves Letter Book), with correspondence dating from 1846 to 1860, is held in the Baker Library at the Harvard Business School, Cambridge, Massachusetts.</lds01>
+    <lds03>The collection consists primarily of business letters and records retained by William Graves, Jr., in the course of managing his shipping interests after his retirement from the sea (1847). There are some 330 letters, 1850 to 1875, mostly directed to Graves (accompanied by a few retained copies of letters written by him). Much of this correspondence relates to the affairs of the ships George West, Castilian, and Josiah L. Hale. Many were written by the masters of these ships, who functioned as the owners' agent or proxy abroad. Among the most recurrent of these correspondents are Alexander Graves, Edward Graves, Edmund Pike, Samuel Pike, Robert Couch, Nehemiah Proctor, and James W. Snow. Because many of these men were Graves's relations there is often some personal content, but the letters were prompted by ship's business. There are also letters from bankers (including Barring Brothers, Graves's banker in London), ship brokers and commission merchants, and agents for other kinds of concerns. Also in the collection are a substantial number of records of the above-named ships. These include more than 460 items for George West (1855-1864); more than 880 for Castilian (1853-1866); and more than 670 for Josiah L. Hale (1857-1874). Record types include, but are not limited to, freight lists and accounts, receipts, disbursements, vouchers, customs papers, and insurance policies and charters, bearing on everything from the ship's itinerary and cargo to its outfitting, repairs, and crew. These are essentially business and financial records; strictly nautical records (like logs) are generally lacking. The collection also includes a small number of papers of William Graves, Sr. (around 70 items, 1812-1841), and an accumulation of financial records of the Wetmore family of Rhode Island and Connecticut (around 90 items, 1821-1837).</lds03>
+    <lds03>Series 1: William Graves, Papers</lds03>
+    <lds03>William Graves, Sr., miscellaneous documents,</lds03>
+    <lds03>William Graves, Sr., Ship Plutarch documents,</lds03>
+    <lds03>William Graves, Sr., Ship Calumet documents,</lds03>
+    <lds03>Series 2: William Graves Jr., Correspondence</lds03>
+    <lds03>William Graves, Jr., correspondence,</lds03>
+    <lds03>Series 3: Ship George West, Records</lds03>
+    <lds03>[This folder is not in use].</lds03>
+    <lds03>Ship George West, miscellaneous documents,</lds03>
+    <lds03>Ship George West, insurance policies and charters,</lds03>
+    <lds03>Series 4: Ship Castilian, Records</lds03>
+    <lds03>Ship Castilian, miscellaneous documents,</lds03>
+    <lds03>Ship Castilian, insurance policies and charters,</lds03>
+    <lds03>Series 5: Ship Josiah L. Hale, Records</lds03>
+    <lds03>Ship Josiah L. Hale, miscellaneous documents,</lds03>
+    <lds03>Ship Josiah L. Hale, insurance policies and charters,</lds03>
+    <lds03>Series 6: Unidentified Ships, Records</lds03>
+    <lds03>Documents from unidentified ships,</lds03>
+    <lds03>Series 7: Wetmore Family Papers</lds03>
+    <lds03>Wetmore family papers,</lds03>
+    <lds04>William Graves, Sr., was born at Salisbury, Massachusetts on 23 August 1785, the son of Mark and Abigail Green Graves. He must have worked aboard ship from an early age, for at 18 he was already master of the Salem brig Henry (William Ward, owner). From 1810 to 1817 he was captain of the Newburyport brig Abigail, making regular commercial voyages between Virginia and Europe. In 1809 Graves married Mary Pike of Salisbury; a son, William, Jr., was born on 21 March 1811. Mary Graves died in 1817; William subsequently married her sister, Susannah Pike, with whom he had two more sons: Alexander (1823-1869) and Edward (1831-1873). All three sons—William, Jr. and his two half-brothers—would become successful ship masters (and, like their father, members of the Newburyport Marine Society). From the 1820s into the 1840s Graves continued at sea, ultimately commanding at least 18 vessels; in several cases he is listed as part-owner. Among his ships mentioned in the present papers are Plutarch (1824-25) and Calumet (1826-1829), both of Newburyport. In the mid-1820s Graves moved his family from Salisbury to Newburyport; around this time, also, William Graves, Jr. would have begun making voyages on his father's ships, training for a career as a master mariner. In 1834 the Salem merchants David Pingree and Emery Johnson entrusted the younger William Graves with the command of their bark Cynthia, bound for Canton, China. Graves made three voyages to China in Cynthia (1834-37) and six more as master of Pingree and Johnson's new and larger (595 tons) ship Thomas Perkins (1837-47). After more than a decade of near-continuous sailing in the China trade Graves found himself financially secure, and retired from the sea at age 37. He built a house at 56 High St., Newburyport, and married his 24-year-old cousin Mary Pike (1848). In 1849 he set up offices at 8 Ferry Wharf and with his business partner Micajah Lunt began buying substantial interests in sailing ships of the 1000-ton class, built in the shipyard of John Currier, Jr. of Newburyport. Among these vessels were Castilian (built 1849); Volant (1853); Gleaner (1854); George West (1855); Josiah L. Hale (1857); Kenmore (1861); Winona (1862); and Tennyson (1865). These ships engaged in commerce world-wide, contracting with merchants in foreign and domestic ports to carry every manner of cargo. For example, two contracts (or charter-parties) of 8 September 1862 stipulate that George West, then at Amsterdam, sail to Sunderland, England to take on a load of coal bound for Madras, in India; from Madras she was to proceed to Burma for a full cargo of rice, and return with that cargo to a port in northwest Europe. Graves and his fellow owners were to be paid £25 per keel (21.2 long tons) of coal delivered, and £4 per long ton for the rice. Charters between merchants and shipowners were typically arranged by a ship broker (in this case George Croshaw &amp; Co. of London). Sometimes Graves contracted to carry passengers. In addition to the Newburyport ships indicated above, Graves bought shares in several Salem vessels, including the barks Arthur Pickering and Dragon. On occasion his ships were commanded by his brothers, Alexander and Edward, or by his brother-in-law Edmund J. Pike. Apart from managing his shipping business, Graves took an active role in civic affairs in Newburyport, serving as alderman and mayor. He was also president of the Newburyport Marine Society, president of Bartlett Steam Mills, and a director of the Merchants' National Bank. Graves was twice married, to Caroline Wells (d. 1838) and Mary Pike. He died on 1 September 1877 at the age of 66. Three vessels co-owned by William Graves, Jr. figure prominently in the papers. The ship George West (1122 tons) was built by Currier in 1855. Graves was managing owner; also holding interests were Benjamin A. West of Salem, Robert Couch, Philip H. Blumpy, Joshua Hale, and John Currier, Jr. The ship's masters were Robert Couch (1855-60); George Lunt (1861-62); and Joseph W. Snow, Jr. (1862-64). George West was operated by Graves and his partners from 1855 to 1864, when she was sold at Liverpool to British interests. Prior to the Civil War she was much engaged in the Atlantic cotton trade. A second ship whose papers are well represented is Castilian (999 tons), built by Currier in 1849 and launched in early 1850; Micajah Lunt was the ship's first managing owner (1850-1857), followed by William Graves, Jr. (1857-1867). Her first master was Alexander Graves (1850-1860), who was succeeded by Nehemiah Proctor (1860-1863) and Edmund J. Pike (from 1863). Castilian was periodically engaged in the Peruvian guano trade, and made a number of voyages to ports in South and East Asia. In 1860 she carried 400 Africans from the seized slave ship Wildfire to Liberia on the west coast of Africa, under the aegis of the American Colonization Society. In 1857, Graves and his partners took receipt of the newly built Josiah L. Hale (1094 tons); masters were Jeremiah Lunt, Edward Graves (William's younger half-brother), Edmund Pike, and Samuel Pike. During some sixteen years of operation under Graves and his fellow owners, Hale travelled the Atlantic, Pacific, and Indian Oceans, destined for ports in North and South America, northwest Europe, India, Burma, China, and Australia. The damaged ship was sold in 1873, to Norwegian interests.</lds04>
+    <availinstitution>$$INDU$$Savailable</availinstitution>
+    <availpnx>available</availpnx>
+  </display>
+  <links>
+    <linktofa>$$Uhttp://rbsc.library.nd.edu/finding_aid/RBSC-MSNEA0506:143$$DFull description / Finding Aid</linktofa>
+  </links>
+  <search>
+    <creatorcontrib>William Graves Jr, 1811 - 1877)</creatorcontrib>
+    <creatorcontrib>William Graves, 1811-1877</creatorcontrib>
+    <creatorcontrib>Graves, William, Jr. (1811-1877)</creatorcontrib>
+    <title>Graves family shipping papers</title>
+    <description>About 2500 manuscript business papers of the Graves family, captains and shipowners of Newburyport, Massachusetts, with an emphasis on the incoming correspondence of William Graves, Jr. (1811-1877) and records of his ships Castilian, George West, and Josiah L. Hale.</description>
+    <subject>Newburyport (Mass.) -- Business, industries, and trades -- Shipping</subject>
+    <subject>Shipping -- Massachusetts</subject>
+    <subject>Ships -- Cargo</subject>
+    <subject>Massachusetts -- Commerce</subject>
+    <subject>India -- Commerce -- United States</subject>
+    <subject>Great Britain -- Commerce -- United States</subject>
+    <subject>Graves, William, Jr. (1811-1877)</subject>
+    <subject>Graves, William (1785-1851)</subject>
+    <subject>George West (Ship)</subject>
+    <subject>Castilian (Ship)</subject>
+    <subject>Josiah L. Hale (Ship)</subject>
+    <general>AllDocuments</general>
+    <general>About 2500 manuscript business papers of the Graves family, captains and shipowners of Newburyport, Massachusetts, with an emphasis on the incoming correspondence of William Graves, Jr. (1811-1877) and records of his ships Castilian, George West, and Josiah L. Hale.</general>
+    <general>William Graves, Sr., was born at Salisbury, Massachusetts on 23 August 1785, the son of Mark and Abigail Green Graves. He must have worked aboard ship from an early age, for at 18 he was already master of the Salem brig Henry (William Ward, owner). From 1810 to 1817 he was captain of the Newburyport brig Abigail, making regular commercial voyages between Virginia and Europe. In 1809 Graves married Mary Pike of Salisbury; a son, William, Jr., was born on 21 March 1811. Mary Graves died in 1817; William subsequently married her sister, Susannah Pike, with whom he had two more sons: Alexander (1823-1869) and Edward (1831-1873). All three sons—William, Jr. and his two half-brothers—would become successful ship masters (and, like their father, members of the Newburyport Marine Society). From the 1820s into the 1840s Graves continued at sea, ultimately commanding at least 18 vessels; in several cases he is listed as part-owner. Among his ships mentioned in the present papers are Plutarch (1824-25) and Calumet (1826-1829), both of Newburyport. In the mid-1820s Graves moved his family from Salisbury to Newburyport; around this time, also, William Graves, Jr. would have begun making voyages on his father's ships, training for a career as a master mariner. In 1834 the Salem merchants David Pingree and Emery Johnson entrusted the younger William Graves with the command of their bark Cynthia, bound for Canton, China. Graves made three voyages to China in Cynthia (1834-37) and six more as master of Pingree and Johnson's new and larger (595 tons) ship Thomas Perkins (1837-47). After more than a decade of near-continuous sailing in the China trade Graves found himself financially secure, and retired from the sea at age 37. He built a house at 56 High St., Newburyport, and married his 24-year-old cousin Mary Pike (1848). In 1849 he set up offices at 8 Ferry Wharf and with his business partner Micajah Lunt began buying substantial interests in sailing ships of the 1000-ton class, built in the shipyard of John Currier, Jr. of Newburyport. Among these vessels were Castilian (built 1849); Volant (1853); Gleaner (1854); George West (1855); Josiah L. Hale (1857); Kenmore (1861); Winona (1862); and Tennyson (1865). These ships engaged in commerce world-wide, contracting with merchants in foreign and domestic ports to carry every manner of cargo. For example, two contracts (or charter-parties) of 8 September 1862 stipulate that George West, then at Amsterdam, sail to Sunderland, England to take on a load of coal bound for Madras, in India; from Madras she was to proceed to Burma for a full cargo of rice, and return with that cargo to a port in northwest Europe. Graves and his fellow owners were to be paid £25 per keel (21.2 long tons) of coal delivered, and £4 per long ton for the rice. Charters between merchants and shipowners were typically arranged by a ship broker (in this case George Croshaw &amp; Co. of London). Sometimes Graves contracted to carry passengers. In addition to the Newburyport ships indicated above, Graves bought shares in several Salem vessels, including the barks Arthur Pickering and Dragon. On occasion his ships were commanded by his brothers, Alexander and Edward, or by his brother-in-law Edmund J. Pike. Apart from managing his shipping business, Graves took an active role in civic affairs in Newburyport, serving as alderman and mayor. He was also president of the Newburyport Marine Society, president of Bartlett Steam Mills, and a director of the Merchants' National Bank. Graves was twice married, to Caroline Wells (d. 1838) and Mary Pike. He died on 1 September 1877 at the age of 66. Three vessels co-owned by William Graves, Jr. figure prominently in the papers. The ship George West (1122 tons) was built by Currier in 1855. Graves was managing owner; also holding interests were Benjamin A. West of Salem, Robert Couch, Philip H. Blumpy, Joshua Hale, and John Currier, Jr. The ship's masters were Robert Couch (1855-60); George Lunt (1861-62); and Joseph W. Snow, Jr. (1862-64). George West was operated by Graves and his partners from 1855 to 1864, when she was sold at Liverpool to British interests. Prior to the Civil War she was much engaged in the Atlantic cotton trade. A second ship whose papers are well represented is Castilian (999 tons), built by Currier in 1849 and launched in early 1850; Micajah Lunt was the ship's first managing owner (1850-1857), followed by William Graves, Jr. (1857-1867). Her first master was Alexander Graves (1850-1860), who was succeeded by Nehemiah Proctor (1860-1863) and Edmund J. Pike (from 1863). Castilian was periodically engaged in the Peruvian guano trade, and made a number of voyages to ports in South and East Asia. In 1860 she carried 400 Africans from the seized slave ship Wildfire to Liberia on the west coast of Africa, under the aegis of the American Colonization Society. In 1857, Graves and his partners took receipt of the newly built Josiah L. Hale (1094 tons); masters were Jeremiah Lunt, Edward Graves (William's younger half-brother), Edmund Pike, and Samuel Pike. During some sixteen years of operation under Graves and his fellow owners, Hale travelled the Atlantic, Pacific, and Indian Oceans, destined for ports in North and South America, northwest Europe, India, Burma, China, and Australia. The damaged ship was sold in 1873, to Norwegian interests.</general>
+    <general>The collection consists primarily of business letters and records retained by William Graves, Jr., in the course of managing his shipping interests after his retirement from the sea (1847). There are some 330 letters, 1850 to 1875, mostly directed to Graves (accompanied by a few retained copies of letters written by him). Much of this correspondence relates to the affairs of the ships George West, Castilian, and Josiah L. Hale. Many were written by the masters of these ships, who functioned as the owners' agent or proxy abroad. Among the most recurrent of these correspondents are Alexander Graves, Edward Graves, Edmund Pike, Samuel Pike, Robert Couch, Nehemiah Proctor, and James W. Snow. Because many of these men were Graves's relations there is often some personal content, but the letters were prompted by ship's business. There are also letters from bankers (including Barring Brothers, Graves's banker in London), ship brokers and commission merchants, and agents for other kinds of concerns. Also in the collection are a substantial number of records of the above-named ships. These include more than 460 items for George West (1855-1864); more than 880 for Castilian (1853-1866); and more than 670 for Josiah L. Hale (1857-1874). Record types include, but are not limited to, freight lists and accounts, receipts, disbursements, vouchers, customs papers, and insurance policies and charters, bearing on everything from the ship's itinerary and cargo to its outfitting, repairs, and crew. These are essentially business and financial records; strictly nautical records (like logs) are generally lacking. The collection also includes a small number of papers of William Graves, Sr. (around 70 items, 1812-1841), and an accumulation of financial records of the Wetmore family of Rhode Island and Connecticut (around 90 items, 1821-1837).</general>
+    <general>Robert Couch, master.</general>
+    <general>George Lunt, master.</general>
+    <general>Joseph W. Snow, master.</general>
+    <general>Alexander Graves, master.</general>
+    <general>Nehemiah Proctor, master.</general>
+    <general>Edmund J. Pike, master.</general>
+    <general>Edmund J Pike, master.</general>
+    <general>Edward Graves, master.</general>
+    <general>Edward Graves, master</general>
+    <general>Robert Nowell, master.</general>
+    <general>David P. Page, master.</general>
+    <general>Samuel W. Pike, master.</general>
+    <sourceid>nduspec_ead</sourceid>
+    <recordid>nduspec_eadRBSC-MSNEA0506</recordid>
+    <recordid>RBSC-MSNEA0506</recordid>
+    <toc>Series 1: William Graves, Papers</toc>
+    <toc>William Graves, Sr., miscellaneous documents,</toc>
+    <toc>William Graves, Sr., Ship Plutarch documents,</toc>
+    <toc>William Graves, Sr., Ship Calumet documents,</toc>
+    <toc>Series 2: William Graves Jr., Correspondence</toc>
+    <toc>William Graves, Jr., correspondence,</toc>
+    <toc>Series 3: Ship George West, Records</toc>
+    <toc>[This folder is not in use].</toc>
+    <toc>Ship George West, miscellaneous documents,</toc>
+    <toc>Ship George West, insurance policies and charters,</toc>
+    <toc>Series 4: Ship Castilian, Records</toc>
+    <toc>Ship Castilian, miscellaneous documents,</toc>
+    <toc>Ship Castilian, insurance policies and charters,</toc>
+    <toc>Series 5: Ship Josiah L. Hale, Records</toc>
+    <toc>Ship Josiah L. Hale, miscellaneous documents,</toc>
+    <toc>Ship Josiah L. Hale, insurance policies and charters,</toc>
+    <toc>Series 6: Unidentified Ships, Records</toc>
+    <toc>Documents from unidentified ships,</toc>
+    <toc>Series 7: Wetmore Family Papers</toc>
+    <toc>Wetmore family papers,</toc>
+    <rsrctype>archival</rsrctype>
+    <searchscope>nduspec_ead</searchscope>
+    <searchscope>NDU</searchscope>
+    <scope>RBSC</scope>
+    <scope>SPEC</scope>
+    <scope>nduspec_ead</scope>
+    <scope>NDU</scope>
+    <alttitle>Guide to the Graves Family Shipping Papers</alttitle>
+    <lsr01>SPEC RBSC</lsr01>
+    <lsr02>Graves Graves family shipping papers</lsr02>
+    <lsr02>Graves family shipping papers Graves</lsr02>
+    <lsr05>MSN/EA 0506</lsr05>
+    <lsr05>MSN/EA0506</lsr05>
+    <lsr05>MSN EA 0506</lsr05>
+    <lsr05>MSN EA0506</lsr05>
+    <lsr05>MSNEA0506</lsr05>
+    <lsr05>MSNEA 0506</lsr05>
+  </search>
+  <sort>
+    <title>graves family shipping papers</title>
+    <creationdate>1850</creationdate>
+    <author>William Graves, Jr, 1811 - 1877)</author>
+    <lso01>1850</lso01>
+    <lso02>MSN/EA 0506</lso02>
+  </sort>
+  <facets>
+    <language>eng</language>
+    <creationdate>1850</creationdate>
+    <topic>Newburyport (Mass.)–Business, industries, and trades–Shipping</topic>
+    <topic>Shipping–Massachusetts</topic>
+    <topic>Ships–Cargo</topic>
+    <topic>Massachusetts–Commerce</topic>
+    <topic>India–Commerce–United States</topic>
+    <topic>Great Britain–Commerce–United States</topic>
+    <topic>Graves, William, Jr. (1811-1877)</topic>
+    <topic>Graves, William (1785-1851)</topic>
+    <topic>George West (Ship)</topic>
+    <topic>Castilian (Ship)</topic>
+    <topic>Josiah L. Hale (Ship)</topic>
+    <toplevel>available</toplevel>
+    <prefilter>archival</prefilter>
+    <prefilter>manuscript</prefilter>
+    <rsrctype>archival</rsrctype>
+    <rsrctype>manuscript</rsrctype>
+    <creatorcontrib>Graves, W</creatorcontrib>
+    <library>HESB</library>
+    <frbrgroupid>148434307</frbrgroupid>
+    <frbrtype>6</frbrtype>
+  </facets>
+  <dedup>
+    <t>99</t>
+  </dedup>
+  <frbr>
+    <t>99</t>
+  </frbr>
+  <delivery>
+    <institution>NDU</institution>
+    <delcategory>Physical Item</delcategory>
+  </delivery>
+  <ranking>
+    <booster1>1</booster1>
+    <booster2>1</booster2>
+  </ranking>
+  <addata>
+    <aulast>Graves</aulast>
+    <aufirst>William</aufirst>
+    <addau>Graves, William, Jr. (1811-1877)</addau>
+    <date>1850</date>
+    <risdate>1812-1877</risdate>
+    <genre>archival</genre>
+    <ristype>GENERIC</ristype>
+    <abstract>About 2500 manuscript business papers of the Graves family, captains and shipowners of Newburyport, Massachusetts, with an emphasis on the incoming correspondence of William Graves, Jr. (1811-1877) and records of his ships Castilian, George West, and Josiah L. Hale.</abstract>
+    <cop>Notre Dame, IN</cop>
+    <pub>Department of Rare Books and Special Collections, University of Notre Dame</pub>
+    <objectid>MSN/EA 0506</objectid>
+  </addata>
+  <browse>
+    <author>$$DGraves, William, Jr. (1811-1877)$$EGraves, William, Jr. (1811-1877)</author>
+    <title>$$DGraves family shipping papers$$EGraves family shipping papers</title>
+    <subject>$$DNewburyport (Mass.) -- Business, industries, and trades -- Shipping$$ENewburyport (Mass.) Business, industries, and trades Shipping</subject>
+    <subject>$$DShipping -- Massachusetts$$EShipping Massachusetts</subject>
+    <subject>$$DShips -- Cargo$$EShips Cargo</subject>
+    <subject>$$DMassachusetts -- Commerce$$EMassachusetts Commerce</subject>
+    <subject>$$DIndia -- Commerce -- United States$$EIndia Commerce United States</subject>
+    <subject>$$DGreat Britain -- Commerce -- United States$$EGreat Britain Commerce United States</subject>
+    <institution>NDU</institution>
+  </browse>
+</record>


### PR DESCRIPTION
We encountered the same issue as @JPrevost where some of our records do not have an originalsourceid control field.  This should resolve #11
