### PR TITLE
Update to Savon 2.8.0

### DIFF
--- a/exlibris-primo.gemspec
+++ b/exlibris-primo.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |s|
   s.add_dependency "json", "~> 1.8.0"
   s.add_dependency "savon", "~> 2.8.0"
   s.add_dependency "iso-639", "~> 0.2.0"
-  s.add_development_dependency "rake", "~> 10.1.0"
-  s.add_development_dependency "vcr", "~> 2.8.0"
-  s.add_development_dependency "webmock", "~> 1.16.0"
+  s.add_development_dependency "rake", "~> 10.1."
+  s.add_development_dependency "vcr", "~> 2.9.0"
+  s.add_development_dependency "webmock", "~> 1.20.0"
   s.add_development_dependency "pry", "~> 0.9.12.2"
   s.add_development_dependency 'minitest', '~> 4.7.5'
 end

--- a/exlibris-primo.gemspec
+++ b/exlibris-primo.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json", "~> 1.8.0"
   s.add_dependency "savon", "~> 2.8.0"
   s.add_dependency "iso-639", "~> 0.2.0"
-  s.add_development_dependency "rake", "~> 10.1."
+  s.add_development_dependency "rake", "~> 10.1"
   s.add_development_dependency "vcr", "~> 2.9.0"
   s.add_development_dependency "webmock", "~> 1.20.0"
   s.add_development_dependency "pry", "~> 0.9.12.2"

--- a/exlibris-primo.gemspec
+++ b/exlibris-primo.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 3.2.14"
   s.add_dependency "nokogiri", "~> 1.6.0"
   s.add_dependency "json", "~> 1.8.0"
-  s.add_dependency "savon", "~> 2.6.0"
+  s.add_dependency "savon", "~> 2.8.0"
   s.add_dependency "iso-639", "~> 0.2.0"
   s.add_development_dependency "rake", "~> 10.1.0"
   s.add_development_dependency "vcr", "~> 2.8.0"


### PR DESCRIPTION
Update gemspec to use Savon v2.8.0 and upgrade versions of development dependencies.
