### PR TITLE
Disable parallel bundle install to fix rbx builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ rvm:
   - 2.1.0
   - jruby-19mode # JRuby (1.9)
   - rbx-2
+install: "bundle install --retry=3"


### PR DESCRIPTION
See travis-ci/travis-ci#2821 and rubygems/rubygems#1005.
